### PR TITLE
Comment-able tabs

### DIFF
--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -322,6 +322,9 @@ struct
                 Tab.Style.inplace
               else
                 rigidInplace
+
+            val style =
+              Tab.Style.combine (style, Tab.Style.allowComments)
           in
             newTabWithStyle tab (style, fn inner1 =>
             newTab inner1 (fn inner2 =>
@@ -537,7 +540,7 @@ struct
                 }))
           end))
     in
-      newTab tab (fn alignedArgsTab =>
+      newTabWithStyle tab (indentedAllowComments, fn alignedArgsTab =>
       newTab tab (fn allArgsGhost =>
         at tab (showExp tab fExp)
         ++
@@ -649,7 +652,7 @@ struct
             ++ (if i = numExps - 1 then empty else nospace ++ token (d i))))
         exps
     in
-      newTabWithStyle outerTab (indented, fn inner =>
+      newTabWithStyle outerTab (indentedAllowComments, fn inner =>
         showThingSimilarToLetInEnd outerTab
           { lett = lett
           , isEmpty1 = decIsEmpty dec
@@ -662,8 +665,9 @@ struct
 
 
   and showIfThenElseAt outer exp =
-    newTabWithStyle outer (indented, fn inner2 =>
-    newTabWithStyle outer (indented, fn inner1 =>
+    newTabWithStyle outer (Tab.Style.allowComments, fn outer =>
+    newTabWithStyle outer (indentedAllowComments, fn inner2 =>
+    newTabWithStyle outer (indentedAllowComments, fn inner1 =>
     let
       open Ast.Exp
       val (chain, last) = ifThenElseChain [] exp
@@ -681,10 +685,11 @@ struct
           at outer (token elsee)
         end
     in
-      Util.loop (0, Seq.length chain) empty (fn (d, i) => d ++ f i)
-      ++
-      breakShowAt inner2 last
-    end))
+      at outer
+        (Util.loop (0, Seq.length chain) empty (fn (d, i) => d ++ f i)
+        ++
+        breakShowAt inner2 last)
+    end)))
 
 
   and showDec tab dec =

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -169,7 +169,7 @@ struct
 
 
   fun showDatbind tab (front, datbind: Ast.Exp.datbind as {elems, delims}) =
-    newTab tab (fn tab =>
+    newTabWithStyle tab (Tab.Style.allowComments, fn tab =>
     let
       fun showCon (starter, {opp, id, arg}) =
         at tab
@@ -554,7 +554,7 @@ struct
 
 
   and showHandle tab {exp=expLeft, handlee, elems, delims} =
-    newTab tab (fn inner =>
+    newTabWithStyle tab (Tab.Style.allowComments, fn inner =>
       let
         fun showBranch {pat, arrow, exp} =
           withNewChild showPat inner pat
@@ -860,6 +860,8 @@ struct
         token colon ++ withNewChild showTy tab ty
 
       fun showClause tab isFirst clauseChildStyle (front, {fname_args, ty, eq, exp}) =
+        (* TODO: need tab style "indented exactly by 2" and align each clause
+         * at this inner tab... works better with inserting comments. *)
         at tab
           ( (if isFirst then empty else cond tab {active=space++space, inactive=empty})
           ++ front
@@ -875,9 +877,12 @@ struct
               Tab.Style.inplace
             else
               indentedAtLeastBy 6
+
+          val mainStyle =
+            Tab.Style.combine (rigidInplace, Tab.Style.allowComments)
         in
           at tab (
-            newTabWithStyle tab (rigidInplace, fn tab =>
+            newTabWithStyle tab (mainStyle, fn tab =>
               Seq.iterate op++
                 (showClause tab true clauseChildStyle (starter, Seq.nth innerElems 0))
                 (Seq.zipWith (showClause tab false clauseChildStyle)

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -25,7 +25,7 @@ struct
    * only difference: there is no possible 'op' in the condesc, ugh.
    *)
   fun showDatspec tab {datatypee, elems, delims} =
-    newTab tab (fn tab =>
+    newTabWithStyle tab (Tab.Style.allowComments, fn tab =>
     let
       fun showCon (starter, {vid, arg}) =
         at tab

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -9,6 +9,7 @@ sig
   type doc = TabbedTokenDoc.doc
   type style = Tab.Style.t
 
+  val indentedAllowComments: style
   val rigidInplace: style
   val indented: style
   val indentedAtLeastBy: int -> style
@@ -56,6 +57,8 @@ struct
   infix 2 ++
   fun x ++ y = concat (x, y)
 
+  val indentedAllowComments =
+    Tab.Style.combine (Tab.Style.indented, Tab.Style.allowComments)
   val rigidInplace =
     Tab.Style.combine (Tab.Style.inplace, Tab.Style.rigid)
   val indented = Tab.Style.indented

--- a/test/fmt/tricky-comments.sml
+++ b/test/fmt/tricky-comments.sml
@@ -1,0 +1,41 @@
+val x =
+  (* try first *)
+  case foobar of
+    (* yo *)
+    Foo f => f (* hello *)
+  | Bar b => b (* world *)
+
+
+val _ =
+  (* try to activate first *)
+  if not (isActivated tab) then
+    setTabState tab (Usable (Activated NONE))
+  else (* if activated, try to relocate *)
+  case getTabState tab of
+
+  (* activated but not placed *)
+    Usable (Activated NONE) =>
+      let
+        val desired = blah blah
+      in
+        setTabState tab (Usable (Activated (SOME desired)))
+      end
+
+  (* activated and already placed *)
+  | Usable (Activated (SOME i)) =>
+      let
+        val desired = blah blah
+      in
+        setTabState tab (Usable (Activated (SOME desired)))
+      end
+
+  | Other => bad (* bad! *)
+
+  | _ => (* how could we get here?? *)
+      raise Fail "bad tab"
+
+
+val _ = (* hello *)
+  Seq.iterate annConcat
+    (* huh *) (Seq.nth all 0)
+    (Seq.map (*okay*) withBreak (*huh*) (Seq.drop all 1))


### PR DESCRIPTION
This fixes an issue with automatic insertion of comments in certain places, for example this output which doesn't look right.

```sml
val _ =
  case foo of
    (* A *)
  Foo => ()
  (* B *)
  | Bar => ()
```

Here, the automatic insertion of a comment screws up the alignment of the two branches, and the indentation of the comments across the branches is not consistent.

After this patch, it looks much better:

```sml
val _ =
  case foo of
  (* A *)
    Foo => ()
  (* B *)
  | Bar => ()
```

### Overview

I created a new tab style (`Tab.Style.allowComments`) which makes the tab work like a "magnet" for comments: any automatically inserted comments are encouraged to move to a nearby magnet. This is implemented by raising comments higher in the document structure, as long the comment doesn't cross a token; see a205f57446969045b1015e6a3bbc072b70807b03. This is similar to the "raise comments" idea from a year or so ago which was implemented in the old layout engine. (For reference, the old work: 006ad1708d6c2e0cfd85e44d8fba43665b5ef8d2)

This allows us to designate certain tabs as good for comments. In this pretty printer, this usually looks like:
```sml
newTabWithStyle tab (Tab.Style.allowComments, fn innerTab => ...)
```

I fixed the above example by designating the left alignment tab of every `case` expression as a good tab for comments. I also did this in a few other places to get better comment placements.