### PR TITLE
Splittable `val` declarations and record rows

### DIFF
--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -716,27 +716,19 @@ struct
 
       | DecVal {vall, tyvars, elems, delims} =>
           let
-            fun mk (delim, {recc, pat, eq, exp}) =
+            fun mk (starter, {recc, pat, eq, exp}) =
               at tab
-                (token delim
+                (starter
                 ++ showOption token recc
                 ++ withNewChild showPat tab pat
                 ++ token eq
                 ++ withNewChild showExp tab exp)
 
-            val first =
-              let
-                val {recc, pat, eq, exp} = Seq.nth elems 0
-              in
-                token vall ++ showTokenSyntaxSeq tab tyvars
-                ++ showOption token recc
-                ++ withNewChild showPat tab pat
-                ++ token eq
-                ++ withNewChild showExp tab exp
-              end
+            val front = token vall ++ showTokenSyntaxSeq tab tyvars
           in
-            Seq.iterate op++ first
-            (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
+            Seq.iterate op++
+              (mk (front, Seq.nth elems 0))
+              (Seq.zipWith mk (Seq.map token delims, Seq.drop elems 1))
           end
 
       | DecFun args =>


### PR DESCRIPTION
Additional uses of splittable expressions, for both `val` declarations and record rows.

OLD OUTPUT
```sml
val hello =
  foo (fn () =>
    { foo =
        bar baz (1, 2, 3)
    , bar =
        beez buzz
          (3, 2, 1)
    })
```

NEW OUTPUT
```sml
val hello = foo (fn () =>
  { foo = bar baz
      (1, 2, 3)
  , bar = beez buzz
      (3, 2, 1)
  })
```