### PR TITLE
Better handling of trailing comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Sam Westrick
+Copyright (c) 2020-2023 Sam Westrick
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2022 Sam Westrick
+(** Copyright (c) 2022-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)
@@ -761,7 +761,7 @@ struct
             fun mkSplittable (starter, {recc, pat, eq, exp}) =
               newTab tab (fn flatGhost =>
               newTab tab (fn expGhost =>
-              newTab tab (fn child =>
+              newTabWithStyle tab (Tab.Style.allowComments, fn child =>
                 let
                   val patContents = withNewChild showPat tab pat
 

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2022 Sam Westrick
+(** Copyright (c) 2022-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)
@@ -85,7 +85,7 @@ struct
       ++ elemShower tab (Seq.nth elems 0)
       ++ nospace ++ token close
     else
-      newTab tab (fn inner =>
+      newTabWithStyle tab (Tab.Style.allowComments, fn inner =>
         let
           val topspacer =
             if


### PR DESCRIPTION
Trailing comments that start on the same line as the previous token are now associated with that token, which results in better automatic insertion of comments.

### Example

INPUT
```sml
val x = a + b (* + c *)

datatype 'a t =
  Empty (* nothing here *)
| One of 'a (* only one element *)
(* more than one element is packaged in a sequence *)
| Many of 'a Seq.t
```

OLD OUTPUT
```sml
val x = a + b
(* + c *)

datatype 'a t =
  Empty
(* nothing to show *)
| One of 'a
(* only one element *)
(* more than one element is packaged in a sequence *)
| Many of 'a Seq.t
```

NEW OUTPUT
```sml
val x = a + b (* + c *)

datatype 'a t =
  Empty (* nothing here *)
| One of 'a (* only one element *)
(* more than one element is packaged in a sequence *)
| Many of 'a Seq.t
```