### PR TITLE
Comment bugfixes

### DIFF
--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -10,7 +10,7 @@ sig
     *)
   val parse: {pathmap: MLtonPathMap.t, skipBasis: bool, allowTopExp: bool}
           -> FilePath.t
-          -> (FilePath.t * Ast.t) Seq.t
+          -> (FilePath.t * Parser.parser_output) Seq.t
 end =
 struct
 
@@ -68,11 +68,11 @@ struct
     TextIO.output (TextIO.stdErr, m)
 
   (** when skipBasis = true, we ignore paths containing $(SML_LIB) *)
-  fun parse {skipBasis, pathmap, allowTopExp} mlbPath : (FilePath.t * Ast.ast) Seq.t =
+  fun parse {skipBasis, pathmap, allowTopExp} mlbPath : (FilePath.t * Parser.parser_output) Seq.t =
     let
       open MLBAst
 
-      type asts = (FilePath.t * Ast.ast) list
+      type asts = (FilePath.t * Parser.parser_output) list
 
       fun expandAndJoin relativeDir path =
         let

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -27,6 +27,8 @@ sig
   val at: tab -> doc -> doc
 
   val toStringDoc: {tabWidth: int, debug: bool} -> doc -> TabbedStringDoc.t
+
+  val justCommentsToStringDoc: {tabWidth: int} -> Token.t Seq.t -> TabbedStringDoc.t
 end =
 struct
 
@@ -749,7 +751,7 @@ struct
 
   fun tokenToStringDoc currentTab tabWidth tok =
     if not (Token.isComment tok orelse Token.isStringConstant tok) then
-      (false, D.text (SyntaxHighlighter.highlightToken tok))
+      D.text (SyntaxHighlighter.highlightToken tok)
     else
     let
       val src = Token.getSource tok
@@ -794,7 +796,7 @@ struct
       val numPieces = Seq.length pieces
     in
       if numPieces = 1 then
-        (false, D.text t)
+        D.text t
       else
         let
           val tab = Tab.new
@@ -814,10 +816,15 @@ struct
           val doc =
             D.newTab (tab, doc)
         in
-          (true, doc)
+          doc
         end
     end
 
+  (* ====================================================================== *)
+
+  fun justCommentsToStringDoc {tabWidth} cs =
+    Seq.iterate D.concat D.empty
+      (Seq.map (fn c => D.at Tab.root (tokenToStringDoc Tab.root tabWidth c)) cs)
 
   (* ====================================================================== *)
 
@@ -858,7 +865,7 @@ struct
                      * tabs here? *)
                     List.hd (TabSet.listKeys tabs)
 
-              val (shouldBeRigid, doc) = tokenToStringDoc tab tabWidth tok
+              val doc = tokenToStringDoc tab tabWidth tok
             in
               doc
             end

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -790,8 +790,10 @@ struct
         Seq.map
           (fn (i, j) => D.text (strip (TCS.substring (t, i, j-i))))
           (Source.lineRanges src)
+
+      val numPieces = Seq.length pieces
     in
-      if Seq.length pieces = 1 then
+      if numPieces = 1 then
         (false, D.text t)
       else
         let
@@ -800,8 +802,15 @@ struct
             , style = Tab.Style.combine (Tab.Style.inplace, Tab.Style.rigid)
             }
           val doc =
+            (* a bit of a hack here: we concatenate a space on the end of
+             * each piece (except last), which guarantees that blank lines
+             * within the comment are preserved.
+             *)
             Seq.iterate D.concat D.empty
-              (Seq.map (fn x => D.at tab x) pieces)
+              (Seq.map (fn x => D.at tab (D.concat (x, D.space)))
+                (Seq.take pieces (numPieces-1)))
+          val doc =
+            D.concat (doc, D.at tab (Seq.nth pieces (numPieces-1)))
           val doc =
             D.newTab (tab, doc)
         in


### PR DESCRIPTION
A couple small fixes for handling comments.
  1. Preserve blank lines inside a multi-line comment.
  2. Fix edge case: preserve comments in files with only comments and nothing else.