### PR TITLE
Run formatter on own source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Supports SML source files
 [MLton](https://github.com/MLton/mlton) conventions,
 including [MLBasis path maps](http://mlton.org/MLBasisPathMap).
 
+Most of the SML code in this repository (everything in `src`, except `src/lib`)
+has been formatted by `smlfmt`. Take a look!
+
 **Note (Dec 29, 2022)**: changed repository name to `smlfmt` (used to be `parse-sml`).
 
 ## Examples: Error Messages

--- a/src/ast/Ast.sml
+++ b/src/ast/Ast.sml
@@ -15,15 +15,9 @@ struct
 
   val empty = Ast (Seq.empty ())
 
-  structure SyntaxSeq =
-  struct
-    open AstType.SyntaxSeq
-  end
+  structure SyntaxSeq = struct open AstType.SyntaxSeq end
 
-  structure Ty =
-  struct
-    open AstType.Ty
-  end
+  structure Ty = struct open AstType.Ty end
 
   structure Pat =
   struct
@@ -36,7 +30,7 @@ struct
 
     fun unpackForConPat pat =
       case pat of
-        Ident {opp, id} => {opp=opp, id=id}
+        Ident {opp, id} => {opp = opp, id = id}
       | _ => raise Fail "Bug: Ast.Pat.unpackForConPat: invalid argument"
 
     fun isValueIdentifier pat =
@@ -49,8 +43,7 @@ struct
       isValueIdentifier pat
       orelse
       case pat of
-        Typed {pat, ...} =>
-          isValueIdentifier pat
+        Typed {pat, ...} => isValueIdentifier pat
       | _ => false
 
     (** Not that the unpacked id has to be a "short" identifer. We could
@@ -59,10 +52,7 @@ struct
     fun unpackForAsPat pat =
       case pat of
         Ident {opp, id} =>
-          { opp = opp
-          , id = MaybeLongToken.getToken id
-          , ty = NONE
-          }
+          {opp = opp, id = MaybeLongToken.getToken id, ty = NONE}
       | Typed {pat = Ident {opp, id}, colon, ty} =>
           { opp = opp
           , id = MaybeLongToken.getToken id
@@ -83,16 +73,18 @@ struct
       | _ => false
 
     fun isAppPat pat =
-      isAtPat pat orelse
+      isAtPat pat
+      orelse
       (case pat of
-        Con _ => true
-      | _ => false)
+         Con _ => true
+       | _ => false)
 
     fun isInfPat pat =
-      isAppPat pat orelse
+      isAppPat pat
+      orelse
       (case pat of
-        Infix _ => true
-      | _ => false)
+         Infix _ => true
+       | _ => false)
 
     fun leftMostToken pat =
       case pat of
@@ -100,17 +92,23 @@ struct
       | Unit {left, ...} => left
       | Const t => t
       | Ident {opp, id} =>
-          (case opp of SOME t => t | NONE => MaybeLongToken.getToken id)
+          (case opp of
+             SOME t => t
+           | NONE => MaybeLongToken.getToken id)
       | List {left, ...} => left
       | Tuple {left, ...} => left
       | Record {left, ...} => left
       | Parens {left, ...} => left
       | Con {opp, id, ...} =>
-          (case opp of SOME t => t | NONE => MaybeLongToken.getToken id)
+          (case opp of
+             SOME t => t
+           | NONE => MaybeLongToken.getToken id)
       | Infix {left, ...} => leftMostToken left
       | Typed {pat, ...} => leftMostToken pat
       | Layered {opp, id, ...} =>
-          (case opp of SOME t => t | NONE => id)
+          (case opp of
+             SOME t => t
+           | NONE => id)
   end
 
   structure Exp =
@@ -132,28 +130,27 @@ struct
       | _ => false
 
     fun isAppExp exp =
-      isAtExp exp orelse
+      isAtExp exp
+      orelse
       (case exp of
-        App _ => true
-      | _ => false)
+         App _ => true
+       | _ => false)
 
     fun isInfExp exp =
-      isAppExp exp orelse
+      isAppExp exp
+      orelse
       (case exp of
-        Infix _ => true
-      | _ => false)
+         Infix _ => true
+       | _ => false)
 
     fun isMultipleDecs dec =
       case dec of
-        DecMultiple {elems, ...} =>
-          Seq.length elems > 1
+        DecMultiple {elems, ...} => Seq.length elems > 1
       | _ => false
 
     (** All the names have to match. *)
-    fun checkValidFValBind
-      (fvalbind: exp fvalbind)
-      (error: {what: string, pos: Source.t, explain: string option} -> unit)
-      =
+    fun checkValidFValBind (fvalbind: exp fvalbind)
+      (error: {what: string, pos: Source.t, explain: string option} -> unit) =
       let
         fun getName {fname_args, ...} =
           case fname_args of
@@ -165,12 +162,14 @@ struct
           let
             val fname = getName (Seq.nth elems 0)
             fun checkName clause =
-              if Token.same (getName clause, fname) then () else
-              error
-                { pos = Token.getSource (getName clause)
-                , what = "Function name does not match."
-                , explain = NONE
-                }
+              if Token.same (getName clause, fname) then
+                ()
+              else
+                error
+                  { pos = Token.getSource (getName clause)
+                  , what = "Function name does not match."
+                  , explain = NONE
+                  }
           in
             Seq.applyIdx (Seq.drop elems 1) (fn (_, elem) => checkName elem)
           end
@@ -188,8 +187,7 @@ struct
 
     fun isMultipleDecs dec =
       case dec of
-        DecMultiple {elems, ...} =>
-          Seq.length elems > 1
+        DecMultiple {elems, ...} => Seq.length elems > 1
       | _ => false
   end
 

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -28,10 +28,10 @@ struct
       Empty
     | One of 'a
     | Many of
-        { left: Token.t         (** open paren *)
-        , elems: 'a Seq.t       (** elements *)
+        { left: Token.t (** open paren *)
+        , elems: 'a Seq.t (** elements *)
         , delims: Token.t Seq.t (** commas between elements *)
-        , right: Token.t        (** close paren *)
+        , right: Token.t (** close paren *)
         }
   end
 
@@ -53,30 +53,16 @@ struct
         }
 
     (** ty * ... * ty *)
-    | Tuple of
-        { elems: ty Seq.t
-        , delims: Token.t Seq.t
-        }
+    | Tuple of {elems: ty Seq.t, delims: Token.t Seq.t}
 
     (** tyseq longtycon *)
-    | Con of
-        { args: ty SyntaxSeq.t
-        , id: MaybeLongToken.t
-        }
+    | Con of {args: ty SyntaxSeq.t, id: MaybeLongToken.t}
 
     (** ty -> ty *)
-    | Arrow of
-        { from: ty
-        , arrow: Token.t
-        , to: ty
-        }
+    | Arrow of {from: ty, arrow: Token.t, to: ty}
 
     (** ( ty ) *)
-    | Parens of
-        { left: Token.t
-        , ty: ty
-        , right: Token.t
-        }
+    | Parens of {left: Token.t, ty: ty, right: Token.t}
 
     type t = ty
   end
@@ -89,13 +75,9 @@ struct
   struct
 
     datatype patrow =
-      DotDotDot of Token.t  (** can only appear at end of record pattern *)
+      DotDotDot of Token.t (** can only appear at end of record pattern *)
 
-    | LabEqPat of
-        { lab: Token.t
-        , eq: Token.t
-        , pat: pat
-        }
+    | LabEqPat of {lab: Token.t, eq: Token.t, pat: pat}
 
     | LabAsPat of
         { id: Token.t
@@ -109,30 +91,20 @@ struct
 
     | Const of Token.t
 
-    | Unit of
-        { left: Token.t
-        , right: Token.t
-        }
+    | Unit of {left: Token.t, right: Token.t}
 
     (** [op] longvid *)
-    | Ident of
-        { opp: Token.t option
-        , id: MaybeLongToken.t
-        }
+    | Ident of {opp: Token.t option, id: MaybeLongToken.t}
 
     (** [ pat, ..., pat ] *)
     | List of
-        { left: Token.t
-        , elems: pat Seq.t
-        , delims: Token.t Seq.t
-        , right: Token.t
-        }
+        {left: Token.t, elems: pat Seq.t, delims: Token.t Seq.t, right: Token.t}
 
     (** ( pat, ..., pat ) *)
     | Tuple of
         { left: Token.t
         , elems: pat Seq.t
-        , delims: Token.t Seq.t  (** Gotta remember the commas too! *)
+        , delims: Token.t Seq.t (** Gotta remember the commas too! *)
         , right: Token.t
         }
 
@@ -145,39 +117,23 @@ struct
         }
 
     (** ( pat ) *)
-    | Parens of
-        { left: Token.t
-        , pat: pat
-        , right: Token.t
-        }
+    | Parens of {left: Token.t, pat: pat, right: Token.t}
 
     (** [op] longvid atpat *)
-    | Con of
-        { opp: Token.t option
-        , id: MaybeLongToken.t
-        , atpat: pat
-        }
+    | Con of {opp: Token.t option, id: MaybeLongToken.t, atpat: pat}
 
     (** pat vid pat *)
-    | Infix of
-        { left: pat
-        , id: Token.t
-        , right: pat
-        }
+    | Infix of {left: pat, id: Token.t, right: pat}
 
     (** pat : ty *)
-    | Typed of
-        { pat: pat
-        , colon: Token.t
-        , ty: Ty.t
-        }
+    | Typed of {pat: pat, colon: Token.t, ty: Ty.t}
 
     (** [op] vid [:ty] as pat *)
     | Layered of
         { opp: Token.t option
         , id: Token.t
         , ty: {colon: Token.t, ty: Ty.t} option
-        , ass: Token.t    (** the `as` of course *)
+        , ass: Token.t (** the `as` of course *)
         , pat: pat
         }
 
@@ -194,11 +150,7 @@ struct
     (** tyvarseq tycon = ty [and tyvarseq tycon = ty ...] *)
     type typbind =
       { elems:
-          { tyvars: Token.t SyntaxSeq.t
-          , tycon: Token.t
-          , eq: Token.t
-          , ty: Ty.t
-          } Seq.t
+          {tyvars: Token.t SyntaxSeq.t, tycon: Token.t, eq: Token.t, ty: Ty.t} Seq.t
       (** the `and` delimiters between bindings *)
       , delims: Token.t Seq.t
       }
@@ -209,17 +161,17 @@ struct
       *)
     type datbind =
       { elems:
-        { tyvars: Token.t SyntaxSeq.t
-        , tycon: Token.t
-        , eq: Token.t
-        , elems:
-            { opp: Token.t option
-            , id: Token.t
-            , arg: {off: Token.t, ty: Ty.t} option
-            } Seq.t
-        (** the `|` delimiters between bindings *)
-        , delims: Token.t Seq.t
-        } Seq.t
+          { tyvars: Token.t SyntaxSeq.t
+          , tycon: Token.t
+          , eq: Token.t
+          , elems:
+              { opp: Token.t option
+              , id: Token.t
+              , arg: {off: Token.t, ty: Ty.t} option
+              } Seq.t
+          (** the `|` delimiters between bindings *)
+          , delims: Token.t Seq.t
+          } Seq.t
 
       (** the `and` delimiters between bindings *)
       , delims: Token.t Seq.t
@@ -242,17 +194,9 @@ struct
       * Note that the arguments always must be atomic patterns
       *)
     datatype fname_args =
-      PrefixedFun of
-        { opp: Token.t option
-        , id: Token.t
-        , args: Pat.t Seq.t
-        }
+      PrefixedFun of {opp: Token.t option, id: Token.t, args: Pat.t Seq.t}
 
-    | InfixedFun of
-        { larg: Pat.t
-        , id: Token.t
-        , rarg: Pat.t
-        }
+    | InfixedFun of {larg: Pat.t, id: Token.t, rarg: Pat.t}
 
     | CurriedInfixedFun of
         { lparen: Token.t
@@ -282,60 +226,41 @@ struct
       }
 
 
-
-
     datatype exp =
       Const of Token.t
 
     (** [op] longvid *)
-    | Ident of
-        { opp: Token.t option
-        , id: MaybeLongToken.t
-        }
+    | Ident of {opp: Token.t option, id: MaybeLongToken.t}
 
     (** { lab = pat, ..., lab = pat } *)
     | Record of
         { left: Token.t
         , elems: {lab: Token.t, eq: Token.t, exp: exp} Seq.t
-        , delims: Token.t Seq.t  (** Gotta remember the commas too! *)
+        , delims: Token.t Seq.t (** Gotta remember the commas too! *)
         , right: Token.t
         }
 
     (** # label *)
-    | Select of
-        { hash: Token.t
-        , label: Token.t
-        }
+    | Select of {hash: Token.t, label: Token.t}
 
     (** () *)
-    | Unit of
-        { left: Token.t
-        , right: Token.t
-        }
+    | Unit of {left: Token.t, right: Token.t}
 
     (** (exp, ..., exp) *)
     | Tuple of
-        { left: Token.t         (** open paren *)
-        , elems: exp Seq.t      (** elements *)
+        { left: Token.t (** open paren *)
+        , elems: exp Seq.t (** elements *)
         , delims: Token.t Seq.t (** commas between elements *)
-        , right: Token.t        (** close paren *)
+        , right: Token.t (** close paren *)
         }
 
     (** [exp, ..., exp] *)
     | List of
-        { left: Token.t
-        , elems: exp Seq.t
-        , delims: Token.t Seq.t
-        , right: Token.t
-        }
+        {left: Token.t, elems: exp Seq.t, delims: Token.t Seq.t, right: Token.t}
 
     (** (exp; ...; exp) *)
     | Sequence of
-        { left: Token.t
-        , elems: exp Seq.t
-        , delims: Token.t Seq.t
-        , right: Token.t
-        }
+        {left: Token.t, elems: exp Seq.t, delims: Token.t Seq.t, right: Token.t}
 
     (** let dec in exp [; exp ...] end *)
     | LetInEnd of
@@ -348,63 +273,40 @@ struct
         }
 
     (** ( exp ) *)
-    | Parens of
-        { left: Token.t
-        , exp: exp
-        , right: Token.t
-        }
+    | Parens of {left: Token.t, exp: exp, right: Token.t}
 
     (** exp exp
       * (Note: needs to be restricted by AtExp < AppExp < InfExp < Exp)
       *)
     | App of
-        { left: exp     (** the function expression *)
-        , right: exp    (** the argument expression *)
+        { left: exp (** the function expression *)
+        , right: exp (** the argument expression *)
         }
 
     (** exp vid exp
       * (Note: needs to be restricted by AtExp < AppExp < InfExp < Exp)
       *)
-    | Infix of
-       { left: exp
-       , id: Token.t
-       , right: exp
-       }
+    | Infix of {left: exp, id: Token.t, right: exp}
 
     (** exp : ty *)
-    | Typed of
-        { exp: exp
-        , colon: Token.t
-        , ty: Ty.t
-        }
+    | Typed of {exp: exp, colon: Token.t, ty: Ty.t}
 
     (** exp andalso exp *)
-    | Andalso of
-        { left: exp
-        , andalsoo: Token.t
-        , right: exp
-        }
+    | Andalso of {left: exp, andalsoo: Token.t, right: exp}
 
     (** exp orelse exp *)
-    | Orelse of
-        { left: exp
-        , orelsee: Token.t
-        , right: exp
-        }
+    | Orelse of {left: exp, orelsee: Token.t, right: exp}
 
     (** exp handle pat => exp [| pat => exp ...] *)
     | Handle of
         { exp: exp
         , handlee: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
-        , delims: Token.t Seq.t   (** the bars between match rules *)
+        , delims: Token.t Seq.t (** the bars between match rules *)
         }
 
     (** raise exp *)
-    | Raise of
-        { raisee: Token.t
-        , exp: exp
-        }
+    | Raise of {raisee: Token.t, exp: exp}
 
     (** if exp then exp else exp *)
     | IfThenElse of
@@ -417,12 +319,7 @@ struct
         }
 
     (** while exp do exp *)
-    | While of
-        { whilee: Token.t
-        , exp1: exp
-        , doo: Token.t
-        , exp2: exp
-        }
+    | While of {whilee: Token.t, exp1: exp, doo: Token.t, exp2: exp}
 
     (** case exp of pat => exp [| pat => exp ...] *)
     | Case of
@@ -430,22 +327,22 @@ struct
         , exp: exp
         , off: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
-        , delims: Token.t Seq.t   (** the bars between match rules *)
+        , delims: Token.t Seq.t (** the bars between match rules *)
         }
 
     (** fn pat => exp [| pat => exp ...] *)
     | Fn of
         { fnn: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
-        , delims: Token.t Seq.t   (** the bars between match rules *)
+        , delims: Token.t Seq.t (** the bars between match rules *)
         }
 
     (** things like _prim, _import, etc.
       * contains arbitrary tokens until ended by a semicolon
       *)
     | MLtonSpecific of
-        { underscore: Token.t  (** must be exactly adjacent to the directive *)
-        , directive: Token.t   (** prim, import, etc. *)
+        { underscore: Token.t (** must be exactly adjacent to the directive *)
+        , directive: Token.t (** prim, import, etc. *)
         , contents: Token.t Seq.t
         , semicolon: Token.t
         }
@@ -458,28 +355,17 @@ struct
     | DecVal of
         { vall: Token.t
         , tyvars: Token.t SyntaxSeq.t
-        , elems:
-            { recc: Token.t option
-            , pat: Pat.t
-            , eq: Token.t
-            , exp: exp
-            } Seq.t
+        , elems: {recc: Token.t option, pat: Pat.t, eq: Token.t, exp: exp} Seq.t
         (** the `and` delimiters between bindings *)
         , delims: Token.t Seq.t
         }
 
     (** fun tyvarseq [op]vid atpat ... atpat [: ty] = exp [| ...] *)
     | DecFun of
-        { funn: Token.t
-        , tyvars: Token.t SyntaxSeq.t
-        , fvalbind: exp fvalbind
-        }
+        {funn: Token.t, tyvars: Token.t SyntaxSeq.t, fvalbind: exp fvalbind}
 
     (** type tyvarseq tycon = ty [and tyvarseq tycon = ty ...] *)
-    | DecType of
-        { typee: Token.t
-        , typbind: typbind
-        }
+    | DecType of {typee: Token.t, typbind: typbind}
 
     (** datatype datbind [withtype typbind] *)
     | DecDatatype of
@@ -495,7 +381,7 @@ struct
         , eq: Token.t
         , right_datatypee: Token.t
         , right_id: MaybeLongToken.t
-       }
+        }
 
     (** abstype datbind [withtype typbind] with dec end *)
     | DecAbstype of
@@ -525,49 +411,29 @@ struct
         }
 
     (** open longstrid [longstrid ...] *)
-    | DecOpen of
-        { openn: Token.t
-        , elems: MaybeLongToken.t Seq.t
-        }
+    | DecOpen of {openn: Token.t, elems: MaybeLongToken.t Seq.t}
 
     (** dec [[;] dec ...]
       *
       * delims are same length as elems (every dec can end with a semicolon)
       *)
-    | DecMultiple of
-        { elems: dec Seq.t
-        , delims: Token.t option Seq.t
-        }
+    | DecMultiple of {elems: dec Seq.t, delims: Token.t option Seq.t}
 
     (** infix [d] vid [vid ...] *)
     | DecInfix of
-        { infixx: Token.t
-        , precedence: Token.t option
-        , elems: Token.t Seq.t
-        }
+        {infixx: Token.t, precedence: Token.t option, elems: Token.t Seq.t}
 
     (** infixr [d] vid [vid ...] *)
     | DecInfixr of
-        { infixrr: Token.t
-        , precedence: Token.t option
-        , elems: Token.t Seq.t
-        }
+        {infixrr: Token.t, precedence: Token.t option, elems: Token.t Seq.t}
 
     (** nonfix vid [vid ...] *)
-    | DecNonfix of
-        { nonfixx: Token.t
-        , elems: Token.t Seq.t
-        }
-
-
+    | DecNonfix of {nonfixx: Token.t, elems: Token.t Seq.t}
 
 
     and exbind =
       ExnNew of
-        { opp: Token.t option
-        , id: Token.t
-        , arg: {off: Token.t, ty: Ty.t} option
-        }
+        {opp: Token.t option, id: Token.t, arg: {off: Token.t, ty: Ty.t} option}
 
     | ExnReplicate of
         { opp: Token.t option
@@ -591,11 +457,7 @@ struct
     (** val vid : ty [and vid : ty and ...] *)
     | Val of
         { vall: Token.t
-        , elems:
-            { vid: Token.t
-            , colon: Token.t
-            , ty: Ty.t
-            } Seq.t
+        , elems: {vid: Token.t, colon: Token.t, ty: Ty.t} Seq.t
         (** 'and' delimiters between mutually recursive values *)
         , delims: Token.t Seq.t
         }
@@ -603,10 +465,7 @@ struct
     (** type tyvarseq tycon [and tyvarseq tycon ...] *)
     | Type of
         { typee: Token.t
-        , elems:
-            { tyvars: Token.t SyntaxSeq.t
-            , tycon: Token.t
-            } Seq.t
+        , elems: {tyvars: Token.t SyntaxSeq.t, tycon: Token.t} Seq.t
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
         }
@@ -614,11 +473,7 @@ struct
     | TypeAbbreviation of
         { typee: Token.t
         , elems:
-            { tyvars: Token.t SyntaxSeq.t
-            , tycon: Token.t
-            , eq: Token.t
-            , ty: Ty.t
-            } Seq.t
+            {tyvars: Token.t SyntaxSeq.t, tycon: Token.t, eq: Token.t, ty: Ty.t} Seq.t
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
         }
@@ -626,10 +481,7 @@ struct
     (** eqtype tyvarseq tycon [and tyvarseq tycon ...] *)
     | Eqtype of
         { eqtypee: Token.t
-        , elems:
-            { tyvars: Token.t SyntaxSeq.t
-            , tycon: Token.t
-            } Seq.t
+        , elems: {tyvars: Token.t SyntaxSeq.t, tycon: Token.t} Seq.t
         (** 'and' delimiters between mutually recursive types *)
         , delims: Token.t Seq.t
         }
@@ -641,10 +493,7 @@ struct
             { tyvars: Token.t SyntaxSeq.t
             , tycon: Token.t
             , eq: Token.t
-            , elems:
-                { vid: Token.t
-                , arg: {off: Token.t, ty: Ty.t} option
-                } Seq.t
+            , elems: {vid: Token.t, arg: {off: Token.t, ty: Ty.t} option} Seq.t
             (** '|' delimiters between clauses *)
             , delims: Token.t Seq.t
             } Seq.t
@@ -664,10 +513,7 @@ struct
     (** exception vid [of ty] [and vid [of ty] ...] *)
     | Exception of
         { exceptionn: Token.t
-        , elems:
-            { vid: Token.t
-            , arg: {off: Token.t, ty: Ty.t} option
-            } Seq.t
+        , elems: {vid: Token.t, arg: {off: Token.t, ty: Ty.t} option} Seq.t
         (** 'and' delimiters between exceptions *)
         , delims: Token.t Seq.t
         }
@@ -675,25 +521,15 @@ struct
     (** structure strid : sigexp [and strid : sigep ...] *)
     | Structure of
         { structuree: Token.t
-        , elems:
-            { id: Token.t
-            , colon: Token.t
-            , sigexp: sigexp
-            } Seq.t
+        , elems: {id: Token.t, colon: Token.t, sigexp: sigexp} Seq.t
         , delims: Token.t Seq.t
         }
 
     (** include sigexp *)
-    | Include of
-        { includee: Token.t
-        , sigexp: sigexp
-        }
+    | Include of {includee: Token.t, sigexp: sigexp}
 
     (** include sigid ... sigid *)
-    | IncludeIds of
-        { includee: Token.t
-        , sigids: Token.t Seq.t
-        }
+    | IncludeIds of {includee: Token.t, sigids: Token.t Seq.t}
 
     (** spec sharing type longtycon1 = ... = longtyconn *)
     | SharingType of
@@ -715,22 +551,14 @@ struct
         }
 
     (** spec [[;] spec ...] *)
-    | Multiple of
-        { elems: spec Seq.t
-        , delims: Token.t option Seq.t
-        }
-
+    | Multiple of {elems: spec Seq.t, delims: Token.t option Seq.t}
 
 
     and sigexp =
       Ident of Token.t
 
     (** sig spec end *)
-    | Spec of
-        { sigg: Token.t
-        , spec: spec
-        , endd: Token.t
-        }
+    | Spec of {sigg: Token.t, spec: spec, endd: Token.t}
 
     (** sigexp where type tyvarseq tycon = ty [where type ...]
       *
@@ -756,11 +584,7 @@ struct
     (** signature sigid = sigexp [and ...] *)
       Signature of
         { signaturee: Token.t
-        , elems:
-            { ident: Token.t
-            , eq: Token.t
-            , sigexp: sigexp
-            } Seq.t
+        , elems: {ident: Token.t, eq: Token.t, sigexp: sigexp} Seq.t
 
         (** 'and' between elems *)
         , delims: Token.t Seq.t
@@ -778,31 +602,19 @@ struct
     datatype strexp =
       Ident of MaybeLongToken.t
 
-    | Struct of
-        { structt: Token.t
-        , strdec: strdec
-        , endd: Token.t
-        }
+    | Struct of {structt: Token.t, strdec: strdec, endd: Token.t}
 
     | Constraint of
         { strexp: strexp
-        , colon: Token.t    (** either : or :> *)
+        , colon: Token.t (** either : or :> *)
         , sigexp: Sig.sigexp
         }
 
     | FunAppExp of
-        { funid: Token.t
-        , lparen: Token.t
-        , strexp: strexp
-        , rparen: Token.t
-        }
+        {funid: Token.t, lparen: Token.t, strexp: strexp, rparen: Token.t}
 
     | FunAppDec of
-        { funid: Token.t
-        , lparen: Token.t
-        , strdec: strdec
-        , rparen: Token.t
-        }
+        {funid: Token.t, lparen: Token.t, strdec: strdec, rparen: Token.t}
 
     | LetInEnd of
         { lett: Token.t
@@ -823,9 +635,7 @@ struct
         , elems:
             { strid: Token.t
             , constraint:
-                { colon: Token.t      (** either : or :> *)
-                , sigexp: Sig.sigexp
-                } option
+                {colon: Token.t (** either : or :> *), sigexp: Sig.sigexp} option
             , eq: Token.t
             , strexp: strexp
             } Seq.t
@@ -834,10 +644,7 @@ struct
         , delims: Token.t Seq.t
         }
 
-    | DecMultiple of
-        { elems: strdec Seq.t
-        , delims: Token.t option Seq.t
-        }
+    | DecMultiple of {elems: strdec Seq.t, delims: Token.t option Seq.t}
 
     | DecLocalInEnd of
         { locall: Token.t
@@ -870,11 +677,7 @@ struct
   struct
 
     datatype funarg =
-      ArgIdent of
-        { strid: Token.t
-        , colon: Token.t
-        , sigexp: Sig.sigexp
-        }
+      ArgIdent of {strid: Token.t, colon: Token.t, sigexp: Sig.sigexp}
 
     | ArgSpec of Sig.spec
 
@@ -888,9 +691,7 @@ struct
             , funarg: funarg
             , rparen: Token.t
             , constraint:
-                { colon: Token.t      (** either : or :> *)
-                , sigexp: Sig.sigexp
-                } option
+                {colon: Token.t (** either : or :> *), sigexp: Sig.sigexp} option
             , eq: Token.t
             , strexp: Str.strexp
             } Seq.t
@@ -915,11 +716,8 @@ struct
   | TopExp of {exp: Exp.exp, semicolon: Token.t}
 
   datatype ast =
-    (** optional semicolon after every topdec *)
-    Ast of
-      { topdec: topdec
-      , semicolon: Token.t option
-      } Seq.t
+  (** optional semicolon after every topdec *)
+    Ast of {topdec: topdec, semicolon: Token.t option} Seq.t
 
   type t = ast
 

--- a/src/ast/MaybeLongToken.sml
+++ b/src/ast/MaybeLongToken.sml
@@ -20,8 +20,9 @@ struct
     if Token.isMaybeLongIdentifier tok then
       tok
     else
-      raise Fail ("MaybeLongToken.make: given non-identifier ("
-                  ^ Token.classToString (Token.getClass tok) ^ ")")
+      raise Fail
+        ("MaybeLongToken.make: given non-identifier ("
+         ^ Token.classToString (Token.getClass tok) ^ ")")
 
   fun getToken tok = tok
 

--- a/src/base/Dict.sml
+++ b/src/base/Dict.sml
@@ -15,9 +15,9 @@ sig
 
   exception NotFound
 
-  val empty : 'a dict
-  val isEmpty : 'a dict -> bool
-  val size : 'a dict -> int
+  val empty: 'a dict
+  val isEmpty: 'a dict -> bool
+  val size: 'a dict -> int
   val singleton: Key.t * 'a -> 'a dict
   val insert: 'a dict -> (Key.t * 'a) -> 'a dict
   val lookup: 'a dict -> Key.t -> 'a
@@ -110,10 +110,14 @@ struct
   val unionWith = M.unionWith
   val intersectWith = M.intersectWith
 
-  fun insert d (k, v) = M.insert (d, k, v)
-  fun lookup d k = M.lookup (d, k)
-  fun find d k = M.find (d, k)
-  fun contains d k = M.inDomain (d, k)
+  fun insert d (k, v) =
+    M.insert (d, k, v)
+  fun lookup d k =
+    M.lookup (d, k)
+  fun find d k =
+    M.find (d, k)
+  fun contains d k =
+    M.inDomain (d, k)
 
   fun remove d k =
     #1 (M.remove (d, k))

--- a/src/base/DocVar.sml
+++ b/src/base/DocVar.sml
@@ -17,16 +17,14 @@ struct
   val counter = ref 0
 
   fun new () =
-    let
-      val result = DocVar {id = !counter}
-    in
-      counter := !counter + 1;
-      result
+    let val result = DocVar {id = !counter}
+    in counter := !counter + 1; result
     end
 
-  fun toString (DocVar {id}) = "[v" ^ Int.toString id ^ "]"
+  fun toString (DocVar {id}) =
+    "[v" ^ Int.toString id ^ "]"
 
-  fun compare (DocVar {id=id1}, DocVar {id=id2}) =
+  fun compare (DocVar {id = id1}, DocVar {id = id2}) =
     Int.compare (id1, id2)
 
 end

--- a/src/base/Error.sml
+++ b/src/base/Error.sml
@@ -11,29 +11,22 @@ sig
   | ItemList of string list
   | SourceReference of Source.t
 
-  type t =
-    { header: string
-    , content: element list
-    }
+  type t = {header: string, content: element list}
 
   type err = t
 
   exception Error of err
 
   val lineError:
-    { header: string
-    , pos: Source.t
-    , what: string
-    , explain: string option
-    }
+    {header: string, pos: Source.t, what: string, explain: string option}
     -> err
 
   (** Note: very important that the syntax highlighter given as argument
     * always succeeds. For example, see SyntaxHighlighter.fuzzyHighlight
     *)
   val show: {highlighter: (Source.t -> TerminalColorString.t) option}
-         -> err
-         -> TerminalColorString.t
+            -> err
+            -> TerminalColorString.t
 end =
 struct
 
@@ -46,24 +39,21 @@ struct
   | ItemList of string list
   | SourceReference of Source.t
 
-  type t =
-    { header: string
-    , content: element list
-    }
+  type t = {header: string, content: element list}
 
   type err = t
   exception Error of err
 
   fun spaces n = TextFormat.repeatChar n #" "
 
-  fun lcToStr {line, col} =
-    (* "[line " ^ Int.toString line ^ ", col " ^ Int.toString col ^ "]" *)
+  fun lcToStr {line, col} = (* "[line " ^ Int.toString line ^ ", col " ^ Int.toString col ^ "]" *)
     Int.toString line ^ "." ^ Int.toString col
 
 
   infix 6 ^^
-  fun x ^^ y = TCS.append (x, y)
-  fun $x = TCS.fromString x
+  fun x ^^ y =
+    TCS.append (x, y)
+  fun $ x = TCS.fromString x
 
   fun showElement highlighter desiredWidth e =
     let
@@ -71,25 +61,25 @@ struct
       val desiredWidth = Int.max (5, desiredWidth)
     in
       case e of
-        Paragraph s =>
-          $ (TextFormat.textWrap desiredWidth s)
+        Paragraph s => $(TextFormat.textWrap desiredWidth s)
 
       | ItemList lns =>
           let
             fun showLine ln =
-              "  " ^ TextFormat.textWrap (desiredWidth-4) (bullet ^ " " ^ ln)
+              "  " ^ TextFormat.textWrap (desiredWidth - 4) (bullet ^ " " ^ ln)
           in
-            TCS.concatWith ($ "\n")
-              (List.map ($ o showLine) lns)
+            TCS.concatWith ($ "\n") (List.map ($ o showLine) lns)
           end
 
       | SourceReference pos =>
           let
-            val {line=lineNum, col=colStart} = Source.absoluteStart pos
-            val {line=lineNum', col=colEnd} = Source.absoluteEnd pos
+            val {line = lineNum, col = colStart} = Source.absoluteStart pos
+            val {line = lineNum', col = colEnd} = Source.absoluteEnd pos
             val _ =
-              if lineNum = lineNum' orelse colEnd = 1 then ()
-              else raise Fail "ErrorReport.show: end of position past end of line"
+              if lineNum = lineNum' orelse colEnd = 1 then
+                ()
+              else
+                raise Fail "ErrorReport.show: end of position past end of line"
 
             val startOffset = Source.absoluteStartOffset pos
             val stopOffset = Source.absoluteEndOffset pos
@@ -102,38 +92,36 @@ struct
 
             val leftMargin = lineNumStr ^ " | "
 
-            val colOffset = colStart-1
+            val colOffset = colStart - 1
 
-            val leftSpaces =
-              spaces (String.size leftMargin + colOffset)
+            val leftSpaces = spaces (String.size leftMargin + colOffset)
 
             val pathName = FilePath.toHostPath (Source.fileName pos)
 
             val numTabsBefore =
               List.length
                 (List.filter (fn c => c = #"\t")
-                  (String.explode (Source.toString (Source.take line colOffset))))
+                   (String.explode (Source.toString
+                      (Source.take line colOffset))))
 
             val line =
               case highlighter of
-                NONE => $ (Source.toString line)
+                NONE => $(Source.toString line)
               | SOME h => h line
-            val line =
-              TCS.translate (fn #"\t" => "  " | c => String.str c) line
+            val line = TCS.translate (fn #"\t" => "  " | c => String.str c) line
 
             val filestyle =
               TCS.foreground lightblue (*o TCS.background lightgray*)
           in
             TCS.concatWith ($ "\n")
-              [ TCS.bold (TCS.underline (filestyle ($ pathName)))
-              , filestyle ($ (spaces marginSize ^ "| "))
-              , filestyle ($ (lineNumStr ^ " | "))
-                  ^^ line
+              [ TCS.bold (TCS.underline (filestyle ($pathName)))
+              , filestyle ($(spaces marginSize ^ "| "))
+              , filestyle ($(lineNumStr ^ " | ")) ^^ line
               , TCS.concat
-                  [ filestyle ($ (spaces marginSize ^ "| "))
-                  , $ (spaces (colOffset + numTabsBefore))
-                  , TCS.bold (TCS.foreground brightred
-                      ($ (TextFormat.repeatChar pointyLen #"^")))
+                  [ filestyle ($(spaces marginSize ^ "| "))
+                  , $(spaces (colOffset + numTabsBefore))
+                  , TCS.bold (TCS.foreground brightred ($
+                      (TextFormat.repeatChar pointyLen #"^")))
                   ]
               (* , spaces marginSize ^ "|" *)
               ]
@@ -143,35 +131,28 @@ struct
 
   fun show {highlighter} {header, content} =
     let
-      val desiredWidth =
-        Int.min (Terminal.currentCols (), 80)
+      val desiredWidth = Int.min (Terminal.currentCols (), 80)
 
-      val headerStr =
-        TextFormat.rightPadWith #"-" desiredWidth ("-- " ^ header ^ " ")
+      val headerStr = TextFormat.rightPadWith #"-" desiredWidth
+        ("-- " ^ header ^ " ")
     in
-      TCS.bold (TCS.foreground brightred ($ headerStr))
-      ^^ $"\n\n"
-      ^^ TCS.concatWith ($"\n\n")
-          (List.map (showElement highlighter desiredWidth) content)
-      ^^ $"\n"
+      TCS.bold (TCS.foreground brightred ($headerStr)) ^^ $ "\n\n"
+      ^^
+      TCS.concatWith ($ "\n\n")
+        (List.map (showElement highlighter desiredWidth) content) ^^ $ "\n"
     end
 
 
   fun lineError {header, pos, what, explain} =
     let
-      val elems =
-        [ Paragraph what
-        , SourceReference pos
-        ]
+      val elems = [Paragraph what, SourceReference pos]
 
       val more =
         case explain of
           NONE => []
         | SOME s => [Paragraph s]
     in
-      { header = header
-      , content = elems @ more
-      }
+      {header = header, content = elems @ more}
     end
 
 end

--- a/src/base/FilePath.sml
+++ b/src/base/FilePath.sml
@@ -3,7 +3,7 @@
   * See the file LICENSE for details.
   *)
 
-structure FilePath:>
+structure FilePath :>
 sig
   type filepath
   type t = filepath
@@ -72,14 +72,11 @@ struct
   fun sameFile (fp1, fp2) =
     Util.equalLists op= (normalize fp1, normalize fp2)
 
-  fun join (fields1, fields2) =
-    fields2 @ fields1
+  fun join (fields1, fields2) = fields2 @ fields1
 
   fun fromUnixPath s =
-    if String.size s = 0 then
-      raise InvalidPathString s
-    else
-      List.rev (String.fields (fn c => c = #"/") s)
+    if String.size s = 0 then raise InvalidPathString s
+    else List.rev (String.fields (fn c => c = #"/") s)
 
   fun toUnixPath s =
     String.concatWith "/" (List.rev s)
@@ -87,8 +84,7 @@ struct
   (** The first field of an (absolute) Unix path is always the empty string.
     * So look at the last, because we represent path fields in reverse order.
     *)
-  fun isAbsolute path =
-    List.last path = ""
+  fun isAbsolute path = List.last path = ""
 
   fun toHostPath path =
     OS.Path.fromUnixPath (toUnixPath path)

--- a/src/base/FindInPath.sml
+++ b/src/base/FindInPath.sml
@@ -38,12 +38,11 @@ struct
       val dirs =
         List.map (FilePath.fromUnixPath o OS.Path.toUnixPath)
           (String.tokens (fn c => c = #":")
-            (Option.valOf (Posix.ProcEnv.getenv "PATH")))
+             (Option.valOf (Posix.ProcEnv.getenv "PATH")))
 
       fun executableInDir dir =
         (List.exists (fn x => x = name) (contents dir)
-        andalso
-        isExecutable (FilePath.join (dir, FilePath.fromFields [name])))
+         andalso isExecutable (FilePath.join (dir, FilePath.fromFields [name])))
         handle _ => false
     in
       case List.find executableInDir dirs of

--- a/src/base/Palette.sml
+++ b/src/base/Palette.sml
@@ -8,17 +8,17 @@ struct
 
   structure TC = TerminalColors
 
-  val green = TC.hsv {h=120.0, s=1.0, v=0.75}
-  val darkgreen = TC.hsv {h=120.0, s=0.8, v=0.45}
-  val red = TC.hsv {h=0.0, s=1.0, v=0.65}
-  val brightred = TC.hsv {h=0.0, s=1.0, v=0.85}
-  val yellow = TC.hsv {h=60.0, s=0.75, v=0.65}
-  val blue = TC.hsv {h=240.0, s=0.65, v=0.85}
-  val lightblue = TC.hsv {h=180.0, s=1.0, v=0.75}
-  val pink = TC.hsv {h=300.0, s=1.0, v=0.75}
-  val purple = TC.hsv {h=269.0, s=0.94, v=1.0}
-  val gray = TC.hsv {h=0.0, s=0.0, v=0.55}
-  val lightgray = TC.hsv {h=0.0, s=0.0, v=0.95}
-  val darkgray = TC.hsv {h=0.0, s=0.0, v=0.05}
+  val green = TC.hsv {h = 120.0, s = 1.0, v = 0.75}
+  val darkgreen = TC.hsv {h = 120.0, s = 0.8, v = 0.45}
+  val red = TC.hsv {h = 0.0, s = 1.0, v = 0.65}
+  val brightred = TC.hsv {h = 0.0, s = 1.0, v = 0.85}
+  val yellow = TC.hsv {h = 60.0, s = 0.75, v = 0.65}
+  val blue = TC.hsv {h = 240.0, s = 0.65, v = 0.85}
+  val lightblue = TC.hsv {h = 180.0, s = 1.0, v = 0.75}
+  val pink = TC.hsv {h = 300.0, s = 1.0, v = 0.75}
+  val purple = TC.hsv {h = 269.0, s = 0.94, v = 1.0}
+  val gray = TC.hsv {h = 0.0, s = 0.0, v = 0.55}
+  val lightgray = TC.hsv {h = 0.0, s = 0.0, v = 0.95}
+  val darkgray = TC.hsv {h = 0.0, s = 0.0, v = 0.05}
 
 end

--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -8,22 +8,22 @@
   *)
 functor PrettyTabbedDoc
   (CustomString:
-    sig
-      type t
-      val substring: t * int * int -> t
+   sig
+     type t
+     val substring: t * int * int -> t
 
-      (* should be visually distinct, e.g., color the background.
-       * the integer argument is a depth; this can be ignored (in which
-       * case all depths will be emphasized the same) or can be used
-       * to distinguish different tab depths
-       *)
-      val emphasize: int -> t -> t
+     (* should be visually distinct, e.g., color the background.
+      * the integer argument is a depth; this can be ignored (in which
+      * case all depths will be emphasized the same) or can be used
+      * to distinguish different tab depths
+      *)
+     val emphasize: int -> t -> t
 
-      val fromString: string -> t
-      val toString: t -> string
-      val size: t -> int
-      val concat: t list -> t
-    end) :>
+     val fromString: string -> t
+     val toString: t -> string
+     val size: t -> int
+     val concat: t list -> t
+   end) :>
 sig
   type doc
   type t = doc
@@ -42,8 +42,8 @@ sig
   val cond: tab -> {inactive: doc, active: doc} -> doc
 
   val pretty: {ribbonFrac: real, maxWidth: int, indentWidth: int, debug: bool}
-           -> doc
-           -> CustomString.t
+              -> doc
+              -> CustomString.t
 
   val toString: doc -> CustomString.t
 end =
@@ -85,10 +85,11 @@ struct
   val newline = Newline
   val space = Space
   val text = Text
-  fun at t d = At (t, d)
+  fun at t d =
+    At (t, d)
 
   fun cond tab {inactive, active} =
-    Cond {tab=tab, inactive=inactive, active=active}
+    Cond {tab = tab, inactive = inactive, active = active}
 
   fun concat (d1, d2) =
     case (d1, d2) of
@@ -145,50 +146,55 @@ struct
 
   fun sentryCmp (se1, se2) =
     case (se1, se2) of
-      (StartTabHighlight {tab=tab1, col=col1}, StartTabHighlight {tab=tab2, col=col2}) =>
+      ( StartTabHighlight {tab = tab1, col = col1}
+      , StartTabHighlight {tab = tab2, col = col2}
+      ) =>
         (case Int.compare (col1, col2) of
-          EQUAL => Tab.compare (tab1, tab2)
-        | other => other)
+           EQUAL => Tab.compare (tab1, tab2)
+         | other => other)
 
-    | (StartTabHighlight {col=col1, ...}, StartMaxWidthHighlight {col=col2}) =>
+    | (StartTabHighlight {col = col1, ...}, StartMaxWidthHighlight {col = col2}) =>
         (case Int.compare (col1, col2) of
-          EQUAL => LESS
-        | other => other)
+           EQUAL => LESS
+         | other => other)
 
-    | (StartMaxWidthHighlight {col=col1}, StartTabHighlight {col=col2, ...}) =>
+    | (StartMaxWidthHighlight {col = col1}, StartTabHighlight {col = col2, ...}) =>
         (case Int.compare (col1, col2) of
-          EQUAL => GREATER
-        | other => other)
+           EQUAL => GREATER
+         | other => other)
 
     | _ => Int.compare (sentryCol se1, sentryCol se2)
 
 
   fun eentryCmp (ee1, ee2) =
     case (ee1, ee2) of
-      (EndTabHighlight {tab=tab1, col=col1}, EndTabHighlight {tab=tab2, col=col2}) =>
+      ( EndTabHighlight {tab = tab1, col = col1}
+      , EndTabHighlight {tab = tab2, col = col2}
+      ) =>
         (case Int.compare (col1, col2) of
-          EQUAL => Tab.compare (tab1, tab2)
-        | other => other)
+           EQUAL => Tab.compare (tab1, tab2)
+         | other => other)
 
-    | (EndTabHighlight {col=col1, ...}, EndMaxWidthHighlight {col=col2}) =>
+    | (EndTabHighlight {col = col1, ...}, EndMaxWidthHighlight {col = col2}) =>
         (case Int.compare (col1, col2) of
-          EQUAL => LESS
-        | other => other)
+           EQUAL => LESS
+         | other => other)
 
-    | (EndMaxWidthHighlight {col=col1}, EndTabHighlight {col=col2, ...}) =>
+    | (EndMaxWidthHighlight {col = col1}, EndTabHighlight {col = col2, ...}) =>
         (case Int.compare (col1, col2) of
-          EQUAL => GREATER
-        | other => other)
+           EQUAL => GREATER
+         | other => other)
 
     | _ => Int.compare (eentryCol ee1, eentryCol ee2)
 
 
   fun matchingStartEndEntries (se, ee) =
     case (se, ee) of
-      (StartTabHighlight {tab=st, col=sc}, EndTabHighlight {tab=et, col=ec, ...}) =>
-        Tab.eq (st, et) andalso sc = ec
+      ( StartTabHighlight {tab = st, col = sc}
+      , EndTabHighlight {tab = et, col = ec, ...}
+      ) => Tab.eq (st, et) andalso sc = ec
 
-    | (StartMaxWidthHighlight {col=sc}, EndMaxWidthHighlight {col=ec}) =>
+    | (StartMaxWidthHighlight {col = sc}, EndMaxWidthHighlight {col = ec}) =>
         sc = ec
 
     | _ => false
@@ -202,8 +208,9 @@ struct
 
   fun sentrytos se =
     case se of
-      StartTabHighlight {tab=st, col=scol} =>
-        "StartTabHighlight {tab = " ^ Tab.name st ^ ", col = " ^ Int.toString scol ^ "}"
+      StartTabHighlight {tab = st, col = scol} =>
+        "StartTabHighlight {tab = " ^ Tab.name st ^ ", col = "
+        ^ Int.toString scol ^ "}"
 
     | StartMaxWidthHighlight {col} =>
         "StartMaxWidthHighlight {col = " ^ Int.toString col ^ "}"
@@ -211,8 +218,9 @@ struct
 
   fun eentrytos ee =
     case ee of
-      EndTabHighlight {tab=et, col=ecol} =>
-        "EndTabHighlight {tab = " ^ Tab.name et ^ ", col = " ^ Int.toString ecol ^ "}"
+      EndTabHighlight {tab = et, col = ecol} =>
+        "EndTabHighlight {tab = " ^ Tab.name et ^ ", col = " ^ Int.toString ecol
+        ^ "}"
 
     | EndMaxWidthHighlight {col} =>
         "EndMaxWidthHighlight {col = " ^ Int.toString col ^ "}"
@@ -256,28 +264,29 @@ struct
           if width item <= 5 then
             "Stuff('" ^ CustomString.toString s ^ "')"
           else
-            "Stuff('" ^ String.substring (CustomString.toString s, 0, 5) ^ "...')"
+            "Stuff('" ^ String.substring (CustomString.toString s, 0, 5)
+            ^ "...')"
       | _ => "???"
 
 
     fun split item i =
-      if i < 0 orelse i+1 > width item then
+      if i < 0 orelse i + 1 > width item then
         raise Fail "PrettyTabbedDoc.Item.split: size"
       else
-      (* i+1 <= width item *)
-      case item of
-        Spaces n =>
-          (Spaces i, CustomString.fromString " ", Spaces (n-i-1))
-      | Stuff s =>
-          let
-            val n = CustomString.size s
-            val left = CustomString.substring (s, 0, i)
-            val mid = CustomString.substring (s, i, 1)
-            val right = CustomString.substring (s, i+1, n-i-1)
-          in
-            (Stuff left, mid, Stuff right)
-          end
-      | _ => raise Fail "PrettyTabbedDoc.Item.split: bad item"
+        (* i+1 <= width item *)
+        case item of
+          Spaces n =>
+            (Spaces i, CustomString.fromString " ", Spaces (n - i - 1))
+        | Stuff s =>
+            let
+              val n = CustomString.size s
+              val left = CustomString.substring (s, 0, i)
+              val mid = CustomString.substring (s, i, 1)
+              val right = CustomString.substring (s, i + 1, n - i - 1)
+            in
+              (Stuff left, mid, Stuff right)
+            end
+        | _ => raise Fail "PrettyTabbedDoc.Item.split: bad item"
 
   end
 
@@ -308,54 +317,57 @@ struct
               val n = Item.width item
             in
               if nextHighlightCol < currCol then
-                processItem (item, (currCol, hi+1, acc))
-              else if currCol+n <= nextHighlightCol then
-                (currCol+n, hi, item :: acc)
+                processItem (item, (currCol, hi + 1, acc))
+              else if currCol + n <= nextHighlightCol then
+                (currCol + n, hi, item :: acc)
               else
                 let
-                  val emphasizer = sentryEmphasizer (Seq.nth orderedHighlightCols hi)
-                  val (left, mid, right) = Item.split item (nextHighlightCol-currCol)
-                  (*
-                  val _ =
-                    print ("item: " ^ itos item
-                       ^ " split into (" ^ itos left ^ ", _, " ^ itos right ^ ")"
-                       ^ " nextHightlightCol: " ^ Int.toString nextHighlightCol
-                       ^ " currCol: " ^ Int.toString currCol
-                       ^ " itemWidth: " ^ Int.toString n
-                       ^ " hi: " ^ Int.toString hi
-                       ^ "\n")
-                  *)
+                  val emphasizer = sentryEmphasizer
+                    (Seq.nth orderedHighlightCols hi)
+                  val (left, mid, right) =
+                    Item.split item (nextHighlightCol - currCol)
+                (*
+                val _ =
+                  print ("item: " ^ itos item
+                     ^ " split into (" ^ itos left ^ ", _, " ^ itos right ^ ")"
+                     ^ " nextHightlightCol: " ^ Int.toString nextHighlightCol
+                     ^ " currCol: " ^ Int.toString currCol
+                     ^ " itemWidth: " ^ Int.toString n
+                     ^ " hi: " ^ Int.toString hi
+                     ^ "\n")
+                *)
                 in
-                  processItem (right,
-                   ( nextHighlightCol + 1
-                   , hi+1
-                   , Item.Stuff (emphasizer mid)
-                     :: left :: acc
-                   ))
+                  processItem
+                    ( right
+                    , ( nextHighlightCol + 1
+                      , hi + 1
+                      , Item.Stuff (emphasizer mid) :: left :: acc
+                      )
+                    )
                 end
             end
 
-          val (currCol, hi, acc) = List.foldr processItem (0, 0, acc) accCurrLine
+          val (currCol, hi, acc) =
+            List.foldr processItem (0, 0, acc) accCurrLine
 
           (* finish out the columns to highlight, if any remaining *)
           val (_, acc) =
             Util.loop (hi, Seq.length orderedHighlightCols) (currCol, acc)
-            (fn ((currCol, acc), hi) =>
-              let
-                val sentry = Seq.nth orderedHighlightCols hi
-                val nextHighlightCol = sentryCol sentry
-                val emphasizer = sentryEmphasizer sentry
-              in
-                if currCol > nextHighlightCol then
-                  (currCol, acc)
-                else
-                  (* currCol <= nextHighlightCol *)
-                  ( nextHighlightCol+1
-                  , Item.Stuff (emphasizer (spaces 1))
-                    :: Item.Spaces (nextHighlightCol-currCol)
-                    :: acc
-                  )
-              end)
+              (fn ((currCol, acc), hi) =>
+                 let
+                   val sentry = Seq.nth orderedHighlightCols hi
+                   val nextHighlightCol = sentryCol sentry
+                   val emphasizer = sentryEmphasizer sentry
+                 in
+                   if currCol > nextHighlightCol then
+                     (currCol, acc)
+                   else
+                     (* currCol <= nextHighlightCol *)
+                     ( nextHighlightCol + 1
+                     , Item.Stuff (emphasizer (spaces 1))
+                       :: Item.Spaces (nextHighlightCol - currCol) :: acc
+                     )
+                 end)
         in
           acc
         end
@@ -365,107 +377,118 @@ struct
         if List.null endDebugs then
           (startDebugs, acc)
         else
-        let
-          val orderedStarts =
-            Mergesort.sort sentryCmp (Seq.fromList startDebugs)
-          val orderedEnds =
-            Mergesort.sort eentryCmp (Seq.fromList endDebugs)
+          let
+            val orderedStarts =
+              Mergesort.sort sentryCmp (Seq.fromList startDebugs)
+            val orderedEnds = Mergesort.sort eentryCmp (Seq.fromList endDebugs)
 
-          val _ =
-            print ("newLineWithEndDebugs:\n"
-                   ^ "  starts: " ^ Seq.toString sentrytos orderedStarts ^ "\n"
-                   ^ "  ends: " ^ Seq.toString eentrytos orderedEnds ^ "\n")
+            val _ = print
+              ("newLineWithEndDebugs:\n" ^ "  starts: "
+               ^ Seq.toString sentrytos orderedStarts ^ "\n" ^ "  ends: "
+               ^ Seq.toString eentrytos orderedEnds ^ "\n")
 
-          (* This is a bit cumbersome, but actually is fairly straightforward:
-           * for each `(info, col)` in `EE`, output `info` at column `col`.
-           *
-           * There's some trickiness though, because multiple `(info, col)`
-           * entries might overlap. For this, we check if each entry fits,
-           * and if not, we add the entry to `didntFit`, and then process
-           * `didntFit` on the next line, repeating until all entries have been
-           * output.
-           *
-           * Update: and now there's more trickiness, because we need to filter
-           * starts as we go to get decent output...
-           *)
-          fun loop
-                (i, SS: sentry Seq.t)
-                (j, EE: eentry Seq.t)
-                (didntFitEE: eentry list)
-                ( removedSSCurrLine: sentry list
-                , remainingSS: sentry list
-                )
-                (currCol: int)
-                (accCurrLine: item list)
-                (acc: item list)
-            =
-            if j >= Seq.length EE then
-              if List.null didntFitEE then
-                let
-                  val remainingSS' = Seq.toList (Seq.drop SS i) @ remainingSS
-                in
-                  ( remainingSS'
-                  , highlightActive accCurrLine acc (removedSSCurrLine @ remainingSS')
-                  )
-                end
-              else
-                loop
-                  (0, Seq.append (Seq.fromRevList remainingSS, Seq.drop SS i))
-                  (0, Seq.fromRevList didntFitEE)
-                  []        (* didntFitEE *)
-                  ([], [])  (* (removedSSCurrLine, remainingSS) *)
-                  0         (* currCol *)
-                  []        (* accCurrLine *)
-                  (Item.Newline :: highlightActive accCurrLine acc
-                    (Seq.toList (Seq.drop SS i) @ remainingSS @ removedSSCurrLine))
-            else
-            let
-              val sentry = Seq.nth SS i
-              val eentry = Seq.nth EE j
-
-              val scol = sentryCol sentry
-              val ecol = eentryCol eentry
-              val info = sentryInfo sentry
-
-              val _ =
-                (* check invariant *)
-                if scol <= ecol then ()
+            (* This is a bit cumbersome, but actually is fairly straightforward:
+             * for each `(info, col)` in `EE`, output `info` at column `col`.
+             *
+             * There's some trickiness though, because multiple `(info, col)`
+             * entries might overlap. For this, we check if each entry fits,
+             * and if not, we add the entry to `didntFit`, and then process
+             * `didntFit` on the next line, repeating until all entries have been
+             * output.
+             *
+             * Update: and now there's more trickiness, because we need to filter
+             * starts as we go to get decent output...
+             *)
+            fun loop (i, SS: sentry Seq.t) (j, EE: eentry Seq.t)
+              (didntFitEE: eentry list)
+              (removedSSCurrLine: sentry list, remainingSS: sentry list)
+              (currCol: int) (accCurrLine: item list) (acc: item list) =
+              if j >= Seq.length EE then
+                if List.null didntFitEE then
+                  let
+                    val remainingSS' = Seq.toList (Seq.drop SS i) @ remainingSS
+                  in
+                    ( remainingSS'
+                    , highlightActive accCurrLine acc
+                        (removedSSCurrLine @ remainingSS')
+                    )
+                  end
                 else
-                  ( print ("sentry " ^ sentrytos sentry ^ "\n"
-                         ^ "eentry " ^ eentrytos eentry ^ "\n"
-                         ^ "i " ^ Int.toString i ^ "\n"
-                         ^ "j " ^ Int.toString j ^ "\n"
-                         ^ "SS " ^ Seq.toString sentrytos SS ^ "\n"
-                         ^ "EE " ^ Seq.toString eentrytos EE ^ "\n")
-                  ; raise Fail "newlineWithEndDebugs.loop: invariant violated"
-                  )
-            in
-              if scol < ecol orelse not (matchingStartEndEntries (sentry, eentry)) then
-                loop (i+1, SS) (j, EE) didntFitEE (removedSSCurrLine, sentry :: remainingSS) currCol accCurrLine acc
-              else if ecol < currCol then
-                loop (i+1, SS) (j+1, EE) (eentry :: didntFitEE) (removedSSCurrLine, sentry :: remainingSS) currCol accCurrLine acc
+                  loop
+                    (0, Seq.append (Seq.fromRevList remainingSS, Seq.drop SS i))
+                    (0, Seq.fromRevList didntFitEE) [] (* didntFitEE *)
+                    ([], []) (* (removedSSCurrLine, remainingSS) *)
+                    0 (* currCol *) [] (* accCurrLine *)
+                    (Item.Newline
+                     ::
+                     highlightActive accCurrLine acc
+                       (Seq.toList (Seq.drop SS i) @ remainingSS
+                        @ removedSSCurrLine))
               else
                 let
-                  val numSpaces = ecol - currCol
-                  val newCol = currCol + numSpaces + CustomString.size info
+                  val sentry = Seq.nth SS i
+                  val eentry = Seq.nth EE j
+
+                  val scol = sentryCol sentry
+                  val ecol = eentryCol eentry
+                  val info = sentryInfo sentry
+
+                  val _ =
+                    (* check invariant *)
+                    if scol <= ecol then
+                      ()
+                    else
+                      ( print
+                          ("sentry " ^ sentrytos sentry ^ "\n" ^ "eentry "
+                           ^ eentrytos eentry ^ "\n" ^ "i " ^ Int.toString i
+                           ^ "\n" ^ "j " ^ Int.toString j ^ "\n" ^ "SS "
+                           ^ Seq.toString sentrytos SS ^ "\n" ^ "EE "
+                           ^ Seq.toString eentrytos EE ^ "\n")
+                      ; raise Fail
+                          "newlineWithEndDebugs.loop: invariant violated"
+                      )
                 in
-                  loop (i+1, SS) (j+1, EE) didntFitEE (sentry :: removedSSCurrLine, remainingSS) newCol (Item.Stuff info :: Item.Spaces numSpaces :: accCurrLine) acc
+                  if
+                    scol < ecol
+                    orelse not (matchingStartEndEntries (sentry, eentry))
+                  then
+                    loop (i + 1, SS) (j, EE) didntFitEE
+                      (removedSSCurrLine, sentry :: remainingSS) currCol
+                      accCurrLine acc
+                  else if
+                    ecol < currCol
+                  then
+                    loop (i + 1, SS) (j + 1, EE) (eentry :: didntFitEE)
+                      (removedSSCurrLine, sentry :: remainingSS) currCol
+                      accCurrLine acc
+                  else
+                    let
+                      val numSpaces = ecol - currCol
+                      val newCol = currCol + numSpaces + CustomString.size info
+                    in
+                      loop (i + 1, SS) (j + 1, EE) didntFitEE
+                        (sentry :: removedSSCurrLine, remainingSS) newCol
+                        (Item.Stuff info :: Item.Spaces numSpaces :: accCurrLine)
+                        acc
+                    end
                 end
-            end
 
-          val (remainingSS, acc) =
-            loop (0, orderedStarts) (0, orderedEnds) [] ([], []) 0 [] (Item.Newline :: acc)
+            val (remainingSS, acc) =
+              loop (0, orderedStarts) (0, orderedEnds) [] ([], []) 0 []
+                (Item.Newline :: acc)
 
-          val acc = highlightActive [] (Item.Newline :: acc) remainingSS
-        in
-          (remainingSS, acc)
-        end
+            val acc = highlightActive [] (Item.Newline :: acc) remainingSS
+          in
+            (remainingSS, acc)
+          end
 
 
       fun processItem (item, (accCurrLine, acc, endDebugs, startDebugs)) =
         case item of
-          Item.EndDebug entry => (accCurrLine, acc, entry :: endDebugs, startDebugs)
-        | Item.StartDebug entry => (accCurrLine, acc, endDebugs, entry :: startDebugs)
+          Item.EndDebug entry =>
+            (accCurrLine, acc, entry :: endDebugs, startDebugs)
+        | Item.StartDebug entry =>
+            (accCurrLine, acc, endDebugs, entry :: startDebugs)
         | Item.Newline =>
             let
               val (remainingSS, acc) =
@@ -478,16 +501,17 @@ struct
 
 
       val init = ([], [], [], [])
-      val init = processItem (Item.StartDebug (StartMaxWidthHighlight {col=maxWidth}), init)
+      val init = processItem
+        (Item.StartDebug (StartMaxWidthHighlight {col = maxWidth}), init)
       val (accCurrLine, acc, endDebugs, startDebugs) =
         List.foldr processItem init
-          (Item.EndDebug (EndMaxWidthHighlight {col=maxWidth}) :: items)
+          (Item.EndDebug (EndMaxWidthHighlight {col = maxWidth}) :: items)
     in
       if List.null endDebugs then
         accCurrLine @ acc
       else
         #2 (newlineWithEndDebugs endDebugs startDebugs
-              (highlightActive accCurrLine acc startDebugs))
+          (highlightActive accCurrLine acc startDebugs))
     end
 
 
@@ -501,18 +525,14 @@ struct
       fun loopStrip acc items =
         case items of
           [] => acc
-        | Item.Spaces _ :: items' =>
-            loopStrip acc items'
-        | _ =>
-            loopKeep acc items
+        | Item.Spaces _ :: items' => loopStrip acc items'
+        | _ => loopKeep acc items
 
       and loopKeep acc items =
         case items of
           [] => acc
-        | Item.Newline :: items' =>
-            loopStrip (Item.Newline :: acc) items'
-        | x :: items' =>
-            loopKeep (x :: acc) items'
+        | Item.Newline :: items' => loopStrip (Item.Newline :: acc) items'
+        | x :: items' => loopKeep (x :: acc) items'
     in
       loopStrip [] items
     end
@@ -525,20 +545,16 @@ struct
     let
       val t0 = Time.now ()
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
-      val ribbonWidth =
-        Int.max (0, Int.min (maxWidth,
-          Real.round (ribbonFrac * Real.fromInt maxWidth)))
+      val ribbonWidth = Int.max (0, Int.min (maxWidth, Real.round
+        (ribbonFrac * Real.fromInt maxWidth)))
 
       val newline = CustomString.fromString "\n"
       val sp = CustomString.fromString " "
 
       datatype activation_state = Flattened | Activated of int option
-      datatype state =
-        Usable of activation_state
-      | Completed
+      datatype state = Usable of activation_state | Completed
 
       val tabstate = ref TabDict.empty
 
@@ -561,24 +577,15 @@ struct
 
       (* debug state, current tab, current 'at's, line start, current col, accumulator *)
       datatype layout_state =
-        LS of
-          debug_state *
-          tab *
-          TabSet.t *
-          int *
-          int *
-          (item list)
+        LS of debug_state * tab * TabSet.t * int * int * (item list)
 
-      fun dbgInsert tab (LS (dbgState, ct, cats, s, c, a): layout_state) : layout_state =
-        if not debug then
-          LS (dbgState, ct, cats, s, c, a)
-        else
-          LS
-            ( TabDict.insert dbgState (tab, false)
-            , ct, cats, s, c, a
-            )
+      fun dbgInsert tab (LS (dbgState, ct, cats, s, c, a) : layout_state) :
+        layout_state =
+        if not debug then LS (dbgState, ct, cats, s, c, a)
+        else LS (TabDict.insert dbgState (tab, false), ct, cats, s, c, a)
 
-      fun dbgBreak tab (LS (dbgState, ct, cats, s, c, a): layout_state) : layout_state =
+      fun dbgBreak tab (LS (dbgState, ct, cats, s, c, a) : layout_state) :
+        layout_state =
         if not debug then
           LS (dbgState, ct, cats, s, c, a)
         else if TabDict.lookup dbgState tab then
@@ -586,7 +593,10 @@ struct
         else
           LS
             ( TabDict.insert dbgState (tab, true)
-            , ct, cats, s, c
+            , ct
+            , cats
+            , s
+            , c
             , Item.StartDebug (StartTabHighlight {tab = tab, col = c}) :: a
             )
 
@@ -596,12 +606,14 @@ struct
         | Usable (Activated NONE) => true
         | Usable (Activated (SOME ti)) =>
             (case Tab.parent t of
-              NONE => false
-            | SOME p =>
-                case getTabState p of
-                  Usable (Activated (SOME pi)) =>
-                    ti > pi + Int.max (indentWidth, Tab.minIndent t)
-                | _ => raise Fail "PrettyTabbedDoc.pretty.isPromotable: bad parent tab")
+               NONE => false
+             | SOME p =>
+                 case getTabState p of
+                   Usable (Activated (SOME pi)) =>
+                     ti > pi + Int.max (indentWidth, Tab.minIndent t)
+                 | _ =>
+                     raise Fail
+                       "PrettyTabbedDoc.pretty.isPromotable: bad parent tab")
         | _ => raise Fail "PrettyTabbedDoc.pretty.isPromotable: bad tab"
 
 
@@ -616,25 +628,22 @@ struct
 
 
       fun oldestPromotableParent t =
-        if not (isPromotable t) then NONE else
-        case Tab.parent t of
-          SOME p =>
-            if not (isPromotable p) then
-              SOME t
-            else
-              oldestPromotableParent p
-        | NONE => SOME t
+        if not (isPromotable t) then
+          NONE
+        else
+          case Tab.parent t of
+            SOME p =>
+              if not (isPromotable p) then SOME t else oldestPromotableParent p
+          | NONE => SOME t
 
 
       fun oldestInactiveParent t =
-        if isActivated t then NONE else
-        case Tab.parent t of
-          SOME p =>
-            if isActivated p then
-              SOME t
-            else
-              oldestInactiveParent p
-        | NONE => SOME t
+        if isActivated t then
+          NONE
+        else
+          case Tab.parent t of
+            SOME p => if isActivated p then SOME t else oldestInactiveParent p
+          | NONE => SOME t
 
 
       (* Below, the `check` function is used to check for layout violations.
@@ -682,20 +691,19 @@ struct
           val widthOkay = col <= maxWidth
           val ribbonOkay = (col - lnStart) <= ribbonWidth
           val okay = widthOkay andalso ribbonOkay
-
-          (* val _ =
-            if not debug orelse okay then ()
-            else if not widthOkay then
-              print ("PrettyTabbedDoc.debug: width violated: ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n")
-            else if not ribbonOkay then
-              print ("PrettyTabbedDoc.debug: ribbon violated: ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n")
-            else
-              print ("PrettyTabbedDoc.debug: unknown violation?? ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n") *)
+            (* val _ =
+              if not debug orelse okay then ()
+              else if not widthOkay then
+                print ("PrettyTabbedDoc.debug: width violated: ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n")
+              else if not ribbonOkay then
+                print ("PrettyTabbedDoc.debug: ribbon violated: ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n")
+              else
+                print ("PrettyTabbedDoc.debug: unknown violation?? ct=" ^ Tab.infoString ct ^ " lnStart=" ^ Int.toString lnStart ^ " col=" ^ Int.toString col ^ "\n") *)
         in
           if okay then
             state
           else
-          case oldestPromotableParent ct of
+            case oldestPromotableParent ct of
             (* TODO: FIXME: there's a bug here. Even if the current tab (ct)
              * doesn't have a promotable parent, there might be another
              * promotable tab on the same line.
@@ -716,8 +724,8 @@ struct
              * we need to keep track of a set of promotable tabs on the
              * current line and then choose one to promote (?)
              *)
-            SOME p => raise DoPromote p
-          | NONE => state
+              SOME p => raise DoPromote p
+            | NONE => state
         end
 
 
@@ -740,9 +748,9 @@ struct
         case Tab.parent tab of
           NONE => raise Fail "PrettyTabbedDoc.pretty.parentTabCol: no parent"
         | SOME p =>
-        case getTabState p of
-          Usable (Activated (SOME i)) => i
-        | _ => raise Fail "PrettyTabbedDoc.pretty.parentTabCol: bad tab"
+            case getTabState p of
+              Usable (Activated (SOME i)) => i
+            | _ => raise Fail "PrettyTabbedDoc.pretty.parentTabCol: bad tab"
 
 
       fun ensureAt tab state =
@@ -754,7 +762,8 @@ struct
             if alreadyAtTab then
               dbgBreak tab (LS (dbgState, tab, cats, lnStart, i, acc))
             else if i = col andalso Tab.isInplace tab then
-              dbgBreak tab (LS (dbgState, tab, TabSet.insert cats tab, lnStart, i, acc))
+              dbgBreak tab (LS
+                (dbgState, tab, TabSet.insert cats tab, lnStart, i, acc))
             else if i < col then
               dbgBreak tab (check (LS
                 ( dbgState
@@ -762,8 +771,8 @@ struct
                 , TabSet.singleton tab
                 , i
                 , i
-                , Item.Spaces i :: Item.Newline :: acc)
-                ))
+                , Item.Spaces i :: Item.Newline :: acc
+                )))
             else if isPromotable tab then
               (* force this tab to promote if possible, which should move
                * it onto a new line and indent. *)
@@ -783,22 +792,24 @@ struct
               dbgBreak tab (check (LS
                 ( dbgState
                 , tab
-                , if i = col then TabSet.insert cats tab else TabSet.singleton tab
+                , if i = col then TabSet.insert cats tab
+                  else TabSet.singleton tab
                 , i
                 , i
-                , Item.Spaces i :: Item.Newline :: acc)
-                ))
+                , Item.Spaces i :: Item.Newline :: acc
+                )))
             else
               (* Fall back on advancing the current line to meet the tab,
                * which is a little strange, but better than nothing. *)
               dbgBreak tab (check (LS
                 ( dbgState
                 , tab
-                , if i = col then TabSet.insert cats tab else TabSet.singleton tab
+                , if i = col then TabSet.insert cats tab
+                  else TabSet.singleton tab
                 , lnStart
                 , i
-                , Item.Spaces (i-col) :: acc)
-                ))
+                , Item.Spaces (i - col) :: acc
+                )))
 
           val state' =
             case getTabState tab of
@@ -808,31 +819,32 @@ struct
                 else
                   LS (dbgState, tab, cats, lnStart, col, acc)
 
-            | Usable (Activated (SOME i)) =>
-                goto i
+            | Usable (Activated (SOME i)) => goto i
 
             | Usable (Activated NONE) =>
                 if Tab.isInplace tab then
                   if col < parentTabCol tab then
-                    ( setTabState tab (Usable (Activated (SOME (parentTabCol tab))))
+                    ( setTabState tab (Usable (Activated
+                        (SOME (parentTabCol tab))))
                     ; goto (parentTabCol tab)
                     )
                   else
-                    ( setTabState tab (Usable (Activated (SOME col)))
-                    ; goto col
-                    )
+                    (setTabState tab (Usable (Activated (SOME col))); goto col)
                 else
                   let
                     val i =
                       parentTabCol tab
-                      + Int.min (Int.max (indentWidth, Tab.minIndent tab), Tab.maxIndent tab)
+                      +
+                      Int.min
+                        ( Int.max (indentWidth, Tab.minIndent tab)
+                        , Tab.maxIndent tab
+                        )
                   in
                     setTabState tab (Usable (Activated (SOME i)));
                     goto i
                   end
 
-            | _ =>
-                raise Fail "PrettyTabbedDoc.pretty.Goto: bad tab"
+            | _ => raise Fail "PrettyTabbedDoc.pretty.Goto: bad tab"
         in
           state'
         end
@@ -848,24 +860,27 @@ struct
        *)
       fun layout (state: layout_state) doc : layout_state =
         case doc of
-          Empty =>
-            state
+          Empty => state
 
-        | Space =>
-            putItemSameLine state (Item.Spaces 1)
+        | Space => putItemSameLine state (Item.Spaces 1)
 
-        | Text s =>
-            putItemSameLine state (Item.Stuff s)
+        | Text s => putItemSameLine state (Item.Stuff s)
 
         | Newline =>
             let
               val LS (dbgState, ct, cats, lnStart, col, acc) = state
             in
-              check (LS (dbgState, ct, cats, col, col, Item.Spaces col :: Item.Newline :: acc))
+              check (LS
+                ( dbgState
+                , ct
+                , cats
+                , col
+                , col
+                , Item.Spaces col :: Item.Newline :: acc
+                ))
             end
 
-        | Concat (doc1, doc2) =>
-            layout (layout state doc1) doc2
+        | Concat (doc1, doc2) => layout (layout state doc1) doc2
 
         | At (tab, doc) =>
             let
@@ -891,43 +906,51 @@ struct
                 if not (isActivated tab) then
                   setTabState tab (Usable (Activated NONE))
                 else (* if activated, try to relocate *)
-                case getTabState tab of
-                  Usable (Activated NONE) =>
-                    let
-                      val desired =
-                        parentTabCol tab
-                        + Int.min (Int.max (indentWidth, Tab.minIndent tab), Tab.maxIndent tab)
-                    in
-                      setTabState tab (Usable (Activated (SOME desired)))
-                    end
-                | Usable (Activated (SOME i)) =>
-                    let
-                      val desired =
-                        Int.min
+                  case getTabState tab of
+                    Usable (Activated NONE) =>
+                      let
+                        val desired =
+                          parentTabCol tab
+                          +
+                          Int.min
+                            ( Int.max (indentWidth, Tab.minIndent tab)
+                            , Tab.maxIndent tab
+                            )
+                      in
+                        setTabState tab (Usable (Activated (SOME desired)))
+                      end
+                  | Usable (Activated (SOME i)) =>
+                      let
+                        val desired = Int.min
                           ( i
                           , parentTabCol tab
-                            + Int.min (Int.max (indentWidth, Tab.minIndent tab), Tab.maxIndent tab)
+                            +
+                            Int.min
+                              ( Int.max (indentWidth, Tab.minIndent tab)
+                              , Tab.maxIndent tab
+                              )
                           )
-                    in
-                      setTabState tab (Usable (Activated (SOME desired)))
-                    end
-                | _ =>
-                    raise Fail "PrettyTabbedDoc.pretty.layout.NewTab.tryPromote: bad tab"
+                      in
+                        setTabState tab (Usable (Activated (SOME desired)))
+                      end
+                  | _ =>
+                      raise Fail
+                        "PrettyTabbedDoc.pretty.layout.NewTab.tryPromote: bad tab"
 
               fun doit () =
                 let in
                   ( ()
                   ; (layout (dbgInsert tab state) doc
-                      handle DoPromote p =>
-                      if not (Tab.eq (p, tab)) then raise DoPromote p else
-                      let
-                        (* val _ =
-                          if not debug then () else
-                          print ("PrettyTabbedDoc.debug: promoting " ^ Tab.infoString tab ^ "\n") *)
-                      in
-                        tryPromote ();
-                        doit ()
-                      end)
+                     handle DoPromote p =>
+                       if not (Tab.eq (p, tab)) then
+                         raise DoPromote p
+                       else
+                         let
+                         (* val _ =
+                           if not debug then () else
+                           print ("PrettyTabbedDoc.debug: promoting " ^ Tab.infoString tab ^ "\n") *)
+                         in tryPromote (); doit ()
+                         end)
                   )
                 end
 
@@ -937,23 +960,33 @@ struct
                 doit ()
 
               val acc =
-                if not debug then acc else
-                case getTabState tab of
-                  Usable Flattened => acc
-                | Usable (Activated NONE) => acc
-                | Usable (Activated (SOME i)) =>
-                    if TabDict.lookup dbgState tab then
-                      Item.EndDebug (EndTabHighlight {tab = tab, col = i}) :: acc
-                    else
-                      acc
-                | _ => raise Fail "PrettyTabbedDoc.debug: error..."
+                if not debug then
+                  acc
+                else
+                  case getTabState tab of
+                    Usable Flattened => acc
+                  | Usable (Activated NONE) => acc
+                  | Usable (Activated (SOME i)) =>
+                      if TabDict.lookup dbgState tab then
+                        Item.EndDebug (EndTabHighlight {tab = tab, col = i})
+                        :: acc
+                      else
+                        acc
+                  | _ => raise Fail "PrettyTabbedDoc.debug: error..."
             in
               (* if not debug then () else
               print ("PrettyTabbedDoc.debug: finishing " ^ Tab.infoString tab ^ "\n"); *)
 
               setTabState tab Completed;
 
-              LS (dbgState, valOf (Tab.parent tab), TabSet.remove cats tab, lnStart, col, acc)
+              LS
+                ( dbgState
+                , valOf (Tab.parent tab)
+                , TabSet.remove cats tab
+                , lnStart
+                , col
+                , acc
+                )
             end
 
       val t1 = Time.now ()
@@ -989,6 +1022,7 @@ struct
     end
 
 
-  val toString = pretty {ribbonFrac = 0.5, maxWidth = 80, indentWidth = 2, debug = false}
+  val toString = pretty
+    {ribbonFrac = 0.5, maxWidth = 80, indentWidth = 2, debug = false}
 
 end

--- a/src/base/Set.sml
+++ b/src/base/Set.sml
@@ -34,9 +34,14 @@ struct
   type set = unit D.t
   type t = set
 
-  fun insert s x = D.insert s (x, ())
-  fun singleton x = D.singleton (x, ())
-  fun fromList xs = D.fromList (List.map (fn x => (x, ())) xs)
-  fun union (s, t) = D.unionWith (fn _ => ()) (s, t)
-  fun intersect (s, t) = D.intersectWith (fn _ => ()) (s, t)
+  fun insert s x =
+    D.insert s (x, ())
+  fun singleton x =
+    D.singleton (x, ())
+  fun fromList xs =
+    D.fromList (List.map (fn x => (x, ())) xs)
+  fun union (s, t) =
+    D.unionWith (fn _ => ()) (s, t)
+  fun intersect (s, t) =
+    D.intersectWith (fn _ => ()) (s, t)
 end

--- a/src/base/Source.sml
+++ b/src/base/Source.sml
@@ -63,35 +63,30 @@ struct
       (** Check that we can use the slice base as the actual base. *)
       val (_, absoluteOffset, _) = ArraySlice.base contents
       val _ =
-        if absoluteOffset = 0 then ()
-        else raise Fail "bug in Source.loadFromFile: expected \
-                        \ReadFile.contentsSeq to return slice at offset 0"
+        if absoluteOffset = 0 then
+          ()
+        else
+          raise Fail
+            "bug in Source.loadFromFile: expected \
+            \ReadFile.contentsSeq to return slice at offset 0"
 
       val newlineIdxs =
-        ArraySlice.full (SeqBasis.filter 2000 (0, n)
-          (fn i => i)
-          (fn i => Seq.nth contents i = #"\n"))
+        ArraySlice.full (SeqBasis.filter 2000 (0, n) (fn i => i) (fn i =>
+          Seq.nth contents i = #"\n"))
     in
-      { data = contents
-      , fileName = path
-      , newlineIdxs = newlineIdxs
-      }
+      {data = contents, fileName = path, newlineIdxs = newlineIdxs}
     end
 
   fun fileName (s: source) = #fileName s
 
   fun absoluteStartOffset ({data, ...}: source) =
-    let
-      val (_, off, _) = ArraySlice.base data
-    in
-      off
+    let val (_, off, _) = ArraySlice.base data
+    in off
     end
 
   fun absoluteEndOffset ({data, ...}: source) =
-    let
-      val (_, off, n) = ArraySlice.base data
-    in
-      off + n
+    let val (_, off, n) = ArraySlice.base data
+    in off + n
     end
 
   fun absoluteStart (s as {newlineIdxs, ...}: source) =
@@ -105,8 +100,7 @@ struct
           if lineNum = 0 then 0 else 1 + Seq.nth newlineIdxs (lineNum - 1)
         val charNum = absoluteStartOffset s - lineOffset
       in
-        (** Convert to 1-indexing *)
-        {line = lineNum+1, col = charNum+1}
+        (** Convert to 1-indexing *) {line = lineNum + 1, col = charNum + 1}
       end
 
   fun length ({data, ...}: source) = Seq.length data
@@ -118,8 +112,10 @@ struct
     , newlineIdxs = newlineIdxs
     }
 
-  fun take s k = slice s (0, k)
-  fun drop s k = slice s (k, length s - k)
+  fun take s k =
+    slice s (0, k)
+  fun drop s k =
+    slice s (k, length s - k)
 
   fun absoluteEnd s =
     absoluteStart (drop s (length s))
@@ -131,10 +127,7 @@ struct
     let
       val (a, _, _) = ArraySlice.base data
     in
-      { data = ArraySlice.full a
-      , fileName = fileName
-      , newlineIdxs = newlineIdxs
-      }
+      {data = ArraySlice.full a, fileName = fileName, newlineIdxs = newlineIdxs}
     end
 
   fun wholeLine (s as {data, fileName, newlineIdxs}: source) lineNum1 =
@@ -145,16 +138,11 @@ struct
       val lineNum0 = lineNum1 - 1
 
       val lineStartOffset =
-        if lineNum0 = 0 then
-          0
-        else
-          1 + Seq.nth newlineIdxs (lineNum0 - 1)
+        if lineNum0 = 0 then 0 else 1 + Seq.nth newlineIdxs (lineNum0 - 1)
 
       val lineEndOffset =
-        if lineNum0 >= Seq.length newlineIdxs then
-          length base
-        else
-          Seq.nth newlineIdxs lineNum0
+        if lineNum0 >= Seq.length newlineIdxs then length base
+        else Seq.nth newlineIdxs lineNum0
 
     in
       slice base (lineStartOffset, lineEndOffset - lineStartOffset)
@@ -163,15 +151,15 @@ struct
 
   fun abut (src1, src2) =
     if
-      FilePath.sameFile (fileName src1, fileName src2) andalso
-      absoluteEndOffset src1 = absoluteStartOffset src2
+      FilePath.sameFile (fileName src1, fileName src2)
+      andalso absoluteEndOffset src1 = absoluteStartOffset src2
     then
       let
         val src = wholeFile src1
         val i = absoluteStartOffset src1
         val j = absoluteEndOffset src2
       in
-        SOME (slice src (i, j-i))
+        SOME (slice src (i, j - i))
       end
     else
       NONE
@@ -180,24 +168,20 @@ struct
   fun lineRanges (s as {newlineIdxs, ...}: source) =
     let
       (** convert back to 0-indexing (-_-) *)
-      val {line=lnStart, ...} = absoluteStart s
-      val lnStart = lnStart-1
-      val {line=lnEnd, ...} = absoluteEnd s
-      val lnEnd = lnEnd-1
+      val {line = lnStart, ...} = absoluteStart s
+      val lnStart = lnStart - 1
+      val {line = lnEnd, ...} = absoluteEnd s
+      val lnEnd = lnEnd - 1
 
-      val numLines = lnEnd-lnStart+1
+      val numLines = lnEnd - lnStart + 1
 
       fun start i =
-        if i = 0 then
-          absoluteStartOffset s
-        else
-          1 + Seq.nth newlineIdxs (lnStart+i-1)
+        if i = 0 then absoluteStartOffset s
+        else 1 + Seq.nth newlineIdxs (lnStart + i - 1)
 
       fun endd i =
-        if i = numLines-1 then
-          absoluteEndOffset s
-        else
-          Seq.nth newlineIdxs (lnStart+i)
+        if i = numLines - 1 then absoluteEndOffset s
+        else Seq.nth newlineIdxs (lnStart + i)
 
       val off = absoluteStartOffset s
     in

--- a/src/base/Tab.sml
+++ b/src/base/Tab.sml
@@ -11,7 +11,7 @@ sig
     type style
     type t = style
 
-    val inplace: style  (* default *)
+    val inplace: style (* default *)
     val indented: style
     val indentedAtLeastBy: int -> style
     val indentedAtMostBy: int -> style
@@ -78,8 +78,8 @@ struct
         (Inplace, Inplace) => Inplace
       | (Inplace, Indented _) => i2
       | (Indented _, Inplace) => i1
-      | ( Indented {minIndent=min1, maxIndent=max1}
-        , Indented {minIndent=min2, maxIndent=max2}
+      | ( Indented {minIndent = min1, maxIndent = max1}
+        , Indented {minIndent = min2, maxIndent = max2}
         ) =>
           Indented
             { minIndent = combineOpts Int.max (min1, min2)
@@ -88,8 +88,8 @@ struct
 
     fun combine (s1, s2) =
       let
-        val S {indent=i1, rigid=r1, allowsComments=c1} = s1
-        val S {indent=i2, rigid=r2, allowsComments=c2} = s2
+        val S {indent = i1, rigid = r1, allowsComments = c1} = s1
+        val S {indent = i2, rigid = r2, allowsComments = c2} = s2
       in
         S { indent = combineIndentStyles (i1, i2)
           , rigid = r1 orelse r2
@@ -97,20 +97,30 @@ struct
           }
       end
 
-    val inplace =
-      S {indent = Inplace, rigid = false, allowsComments = false}
-    val indented =
-      S {indent = Indented {minIndent=NONE, maxIndent=NONE}, rigid = false, allowsComments = false}
+    val inplace = S {indent = Inplace, rigid = false, allowsComments = false}
+    val indented = S
+      { indent = Indented {minIndent = NONE, maxIndent = NONE}
+      , rigid = false
+      , allowsComments = false
+      }
     fun indentedAtLeastBy i =
-      S {indent = Indented {minIndent = SOME i, maxIndent=NONE}, rigid = false, allowsComments = false}
+      S { indent = Indented {minIndent = SOME i, maxIndent = NONE}
+        , rigid = false
+        , allowsComments = false
+        }
     fun indentedAtMostBy i =
-      S {indent = Indented {minIndent=NONE, maxIndent = SOME i}, rigid = false, allowsComments = false}
+      S { indent = Indented {minIndent = NONE, maxIndent = SOME i}
+        , rigid = false
+        , allowsComments = false
+        }
     fun indentedExactlyBy i =
-      S {indent = Indented {minIndent = SOME i, maxIndent = SOME i}, rigid = false, allowsComments = false}
-    val rigid =
-      S {indent = Inplace, rigid = true, allowsComments = false}
-    val allowComments =
-      S {indent = Inplace, rigid = false, allowsComments = true}
+      S { indent = Indented {minIndent = SOME i, maxIndent = SOME i}
+        , rigid = false
+        , allowsComments = false
+        }
+    val rigid = S {indent = Inplace, rigid = true, allowsComments = false}
+    val allowComments = S
+      {indent = Inplace, rigid = false, allowsComments = true}
 
     fun isRigid (S {rigid, ...}) = rigid
 
@@ -129,7 +139,7 @@ struct
         Indented {maxIndent = SOME mi, ...} => mi
       | _ => valOf Int.maxInt
 
-    fun allowsComments (S {allowsComments=c, ...}) = c
+    fun allowsComments (S {allowsComments = c, ...}) = c
   end
 
   (* ===================================================================== *)
@@ -144,11 +154,8 @@ struct
   val tabCounter = ref 0
 
   fun new {parent, style} =
-    let
-      val c = !tabCounter
-    in
-      tabCounter := c+1;
-      Tab {id = c, style = style, parent = parent}
+    let val c = !tabCounter
+    in tabCounter := c + 1; Tab {id = c, style = style, parent = parent}
     end
 
   val root = Root
@@ -161,12 +168,12 @@ struct
   fun style t =
     case t of
       Root => Style.inplace
-    | Tab {style=s, ...} => s
+    | Tab {style = s, ...} => s
 
   fun name t =
     case t of
       Root => "root"
-    | Tab {id=c, ...} => Int.toString c
+    | Tab {id = c, ...} => Int.toString c
 
   fun toString t =
     "[" ^ name t ^ "]"
@@ -184,12 +191,17 @@ struct
   fun depth t =
     case t of
       Root => 0
-    | Tab {parent=p, ...} => 1 + depth p
+    | Tab {parent = p, ...} => 1 + depth p
 
-  fun isRigid t = Style.isRigid (style t)
-  fun isInplace t = Style.isInplace (style t)
-  fun minIndent t = Style.minIndent (style t)
-  fun maxIndent t = Style.maxIndent (style t)
-  fun allowsComments t = Style.allowsComments (style t)
+  fun isRigid t =
+    Style.isRigid (style t)
+  fun isInplace t =
+    Style.isInplace (style t)
+  fun minIndent t =
+    Style.minIndent (style t)
+  fun maxIndent t =
+    Style.maxIndent (style t)
+  fun allowsComments t =
+    Style.allowsComments (style t)
 
 end

--- a/src/base/Terminal.sml
+++ b/src/base/Terminal.sml
@@ -20,7 +20,7 @@ struct
       val p = create
         { path = tputPath
         , env = NONE
-        , args = [ "cols" ]
+        , args = ["cols"]
         , stderr = Param.self
         , stdin = Param.null
         , stdout = Param.pipe

--- a/src/base/TerminalColors.sml
+++ b/src/base/TerminalColors.sml
@@ -32,11 +32,11 @@ struct
   type color = {red: real, green: real, blue: real}
   fun rgb x = x
 
-  val white = {red=1.0, green=1.0, blue=1.0}
-  val black = {red=0.0, green=0.0, blue=0.0}
-  val red = {red=1.0, green=0.0, blue=0.0}
-  val green = {red=0.0, green=1.0, blue=0.0}
-  val blue = {red=0.0, green=0.0, blue=1.0}
+  val white = {red = 1.0, green = 1.0, blue = 1.0}
+  val black = {red = 0.0, green = 0.0, blue = 0.0}
+  val red = {red = 1.0, green = 0.0, blue = 0.0}
+  val green = {red = 0.0, green = 1.0, blue = 0.0}
+  val blue = {red = 0.0, green = 0.0, blue = 1.0}
 
   fun hsv {h, s, v} =
     let
@@ -50,12 +50,12 @@ struct
       val X = C * (1.0 - Real.abs (Real.rem (H', 2.0) - 1.0))
 
       val (R1, G1, B1) =
-        if H' < 1.0 then      (C,   X,   0.0)
-        else if H' < 2.0 then (X,   C,   0.0)
-        else if H' < 3.0 then (0.0, C,   X)
-        else if H' < 4.0 then (0.0, X,   C)
-        else if H' < 5.0 then (X,   0.0, C)
-        else                  (C,   0.0, X)
+        if H' < 1.0 then (C, X, 0.0)
+        else if H' < 2.0 then (X, C, 0.0)
+        else if H' < 3.0 then (0.0, C, X)
+        else if H' < 4.0 then (0.0, X, C)
+        else if H' < 5.0 then (X, 0.0, C)
+        else (C, 0.0, X)
 
       val m = V - C
     in
@@ -68,18 +68,12 @@ struct
   val esc = "\027["
 
   fun background {red, green, blue} =
-    esc ^ "48;2;" ^
-    Int.toString (to256 red) ^ ";" ^
-    Int.toString (to256 green) ^ ";" ^
-    Int.toString (to256 blue) ^
-    "m"
+    esc ^ "48;2;" ^ Int.toString (to256 red) ^ ";" ^ Int.toString (to256 green)
+    ^ ";" ^ Int.toString (to256 blue) ^ "m"
 
   fun foreground {red, green, blue} =
-    esc ^ "38;2;" ^
-    Int.toString (to256 red) ^ ";" ^
-    Int.toString (to256 green) ^ ";" ^
-    Int.toString (to256 blue) ^
-    "m"
+    esc ^ "38;2;" ^ Int.toString (to256 red) ^ ";" ^ Int.toString (to256 green)
+    ^ ";" ^ Int.toString (to256 blue) ^ "m"
 
   val bold = esc ^ "1m"
 

--- a/src/base/TextFormat.sml
+++ b/src/base/TextFormat.sml
@@ -25,18 +25,12 @@ struct
     CharVector.tabulate (n, fn _ => c)
 
   fun leftPadWith char desiredWidth str =
-    if String.size str >= desiredWidth then
-      str
-    else
-      repeatChar (desiredWidth - String.size str) char
-      ^ str
+    if String.size str >= desiredWidth then str
+    else repeatChar (desiredWidth - String.size str) char ^ str
 
   fun rightPadWith char desiredWidth str =
-    if String.size str >= desiredWidth then
-      str
-    else
-      str
-      ^ repeatChar (desiredWidth - String.size str) char
+    if String.size str >= desiredWidth then str
+    else str ^ repeatChar (desiredWidth - String.size str) char
 
   fun centerPadWith char desiredWidth str =
     if String.size str >= desiredWidth then
@@ -47,41 +41,30 @@ struct
         val leftCount = count div 2
         val rightCount = count - leftCount
       in
-        repeatChar leftCount char
-        ^ str
-        ^ repeatChar rightCount char
+        repeatChar leftCount char ^ str ^ repeatChar rightCount char
       end
 
   fun spreadWith char desiredWidth {left, right} =
     if String.size left + String.size right >= desiredWidth then
       left ^ right
     else
-      let
-        val count = desiredWidth - (String.size left + String.size right)
-      in
-        left
-        ^ repeatChar count char
-        ^ right
+      let val count = desiredWidth - (String.size left + String.size right)
+      in left ^ repeatChar count char ^ right
       end
 
   fun textWrap desiredWidth str =
     let
-      fun finishLine ln = String.concatWith " " (List.rev ln)
+      fun finishLine ln =
+        String.concatWith " " (List.rev ln)
       fun loop lines (currLine, currLen) toks =
         case toks of
           tok :: remaining =>
             if currLen + String.size tok + 1 > desiredWidth then
-              loop
-                (finishLine currLine :: lines)
-                ([], 0)
-                toks
+              loop (finishLine currLine :: lines) ([], 0) toks
             else
-              loop
-                lines
-                (tok :: currLine, currLen + String.size tok + 1)
+              loop lines (tok :: currLine, currLen + String.size tok + 1)
                 remaining
-        | [] =>
-            String.concatWith "\n" (List.rev (finishLine currLine :: lines))
+        | [] => String.concatWith "\n" (List.rev (finishLine currLine :: lines))
     in
       loop [] ([], 0) (String.tokens Char.isSpace str)
     end

--- a/src/lex-mlb/MLBToken.sml
+++ b/src/lex-mlb/MLBToken.sml
@@ -10,13 +10,9 @@ sig
     Bas
   | Basis
   | Ann
-  | UnderscorePrim  (** This is MLton-specific *)
+  | UnderscorePrim (** This is MLton-specific *)
 
-  datatype class =
-    SMLPath
-  | MLBPath
-  | Reserved of reserved
-  | SML of Token.class
+  datatype class = SMLPath | MLBPath | Reserved of reserved | SML of Token.class
 
   type t
   type token = t
@@ -45,7 +41,7 @@ sig
     val fromSMLPretoken: Token.Pretoken.t -> pretoken
 
     val makePathFromSource: Source.t -> pretoken option
-    (* val makePathFromSourceString: Source.t -> string -> pretoken option *)
+  (* val makePathFromSourceString: Source.t -> string -> pretoken option *)
   end
 
   val fromPre: Pretoken.t -> token
@@ -58,13 +54,9 @@ struct
     Bas
   | Basis
   | Ann
-  | UnderscorePrim  (** This is MLton-specific *)
+  | UnderscorePrim (** This is MLton-specific *)
 
-  datatype class =
-    SMLPath
-  | MLBPath
-  | Reserved of reserved
-  | SML of Token.class
+  datatype class = SMLPath | MLBPath | Reserved of reserved | SML of Token.class
 
   type pretoken = class WithSource.t
 
@@ -96,8 +88,7 @@ struct
       SML Token.Whitespace => true
     | _ => false
 
-  fun isCommentOrWhitespace tok =
-    isComment tok orelse isWhitespace tok
+  fun isCommentOrWhitespace tok = isComment tok orelse isWhitespace tok
 
   fun isSMLPath tok =
     case getClass tok of
@@ -129,10 +120,8 @@ struct
     ]
 
   fun isBasDecStartToken tok =
-    let
-      val c = getClass tok
-    in
-      List.exists (fn c' => c' = c) basDecStartTokens
+    let val c = getClass tok
+    in List.exists (fn c' => c' = c) basDecStartTokens
     end
 
 
@@ -142,10 +131,10 @@ struct
         if i = 0 then
           NONE
         else
-          case Source.nth src (i-1) of
-            #"." => SOME (i-1)
+          case Source.nth src (i - 1) of
+            #"." => SOME (i - 1)
           | #"/" => NONE
-          | _ => findDot (i-1)
+          | _ => findDot (i - 1)
     in
       case findDot (Source.length src) of
         NONE => NONE
@@ -172,7 +161,7 @@ struct
     | _ => NONE *)
 
 
-  fun makeGroup (s: pretoken Seq.t): token Seq.t =
+  fun makeGroup (s: pretoken Seq.t) : token Seq.t =
     Seq.tabulate (fn i => {idx = i, context = s}) (Seq.length s)
 
   fun fromPre (t: pretoken) =
@@ -192,7 +181,7 @@ struct
     val fromSMLPretoken = fromSMLPretoken
 
     val makePathFromSource = makePathFromSource
-    (* val makePathFromSourceString = makePathFromSourceString *)
+  (* val makePathFromSourceString = makePathFromSourceString *)
   end
 
 end

--- a/src/lex/LexUtils.sml
+++ b/src/lex/LexUtils.sml
@@ -6,34 +6,26 @@
 structure LexUtils =
 struct
 
-  val isValidFormatEscapeChar =
-    Char.contains " \t\n\f\r"
+  val isValidFormatEscapeChar = Char.contains " \t\n\f\r"
 
-  val isValidSingleEscapeChar =
-    Char.contains "abtnvfr\\\""
+  val isValidSingleEscapeChar = Char.contains "abtnvfr\\\""
 
   fun isValidControlEscapeChar c =
     64 <= Char.ord c andalso Char.ord c <= 95
 
-  val isSymbolic =
-    Char.contains "!%&$#+-/:<=>?@\\~`^|*"
+  val isSymbolic = Char.contains "!%&$#+-/:<=>?@\\~`^|*"
 
-  fun isDecDigit c =
-    Char.isDigit c
+  fun isDecDigit c = Char.isDigit c
 
-  fun isHexDigit c =
-    Char.isHexDigit c
+  fun isHexDigit c = Char.isHexDigit c
 
-  fun isLetter c =
-    Char.isAlpha c
+  fun isLetter c = Char.isAlpha c
 
   fun isAlphaNumPrimeOrUnderscore c =
     Char.isAlphaNum c orelse c = #"_" orelse c = #"'"
 
-  val isOtherPathChar =
-    Char.contains "$()_-./"
+  val isOtherPathChar = Char.contains "$()_-./"
 
-  fun isValidUnquotedPathChar c =
-    Char.isAlphaNum c orelse isOtherPathChar c
+  fun isValidUnquotedPathChar c = Char.isAlphaNum c orelse isOtherPathChar c
 
 end

--- a/src/lex/Lexer.sml
+++ b/src/lex/Lexer.sml
@@ -20,16 +20,12 @@ struct
   (** This is just to get around annoying bad syntax highlighting for SML... *)
   val backslash = #"\\" (* " *)
 
-  fun success tok =
-    SOME tok
+  fun success tok = SOME tok
 
   fun error {pos, what, explain} =
-    raise Error.Error (Error.lineError
-      { header = "SYNTAX ERROR"
-      , pos = pos
-      , what = what
-      , explain = explain
-      })
+    raise Error.Error
+      (Error.lineError
+         {header = "SYNTAX ERROR", pos = pos, what = what, explain = explain})
 
 
   fun next (src: Source.t) : Token.Pretoken.t option =
@@ -38,14 +34,16 @@ struct
       val src = Source.wholeFile src
 
       (** Some helpers for making source slices and tokens. *)
-      fun slice (i, j) = Source.slice src (i, j-i)
-      fun mk x (i, j) = Token.Pretoken.make (slice (i, j)) x
-      fun mkr x (i, j) = Token.Pretoken.reserved (slice (i, j)) x
+      fun slice (i, j) =
+        Source.slice src (i, j - i)
+      fun mk x (i, j) =
+        Token.Pretoken.make (slice (i, j)) x
+      fun mkr x (i, j) =
+        Token.Pretoken.reserved (slice (i, j)) x
 
       fun get i = Source.nth src i
 
-      fun isEndOfFileAt s =
-        s >= Source.length src
+      fun isEndOfFileAt s = s >= Source.length src
 
       (** This silliness lets you write almost-English like this:
         *   if is #"x" at i          then ...
@@ -53,17 +51,15 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i = i < Source.length src andalso f (get i)
-      fun is c = check (fn c' => c = c')
+      fun check f i =
+        i < Source.length src andalso f (get i)
+      fun is c =
+        check (fn c' => c = c')
 
 
       (** ====================================================================
         * STRING HANDLING
-        *)
-
-      datatype newcursor =
-        EndOfChar of int
-      | EndOfFormatEscape of int
+        *) datatype newcursor = EndOfChar of int | EndOfFormatEscape of int
 
       (** The follow functions implement a state machine to advance a cursor
         * within a string.
@@ -84,57 +80,55 @@ struct
 
       fun advance_oneCharOrEscapeSequenceInString s (args as {stringStart}) =
         if is backslash at s then
-          advance_inStringEscapeSequence (s+1) args
+          advance_inStringEscapeSequence (s + 1) args
         else if is #"\"" at s then
           NONE
         else if is #"\n" at s orelse isEndOfFileAt s then
           error
-            { pos = slice (stringStart, stringStart+1)
+            { pos = slice (stringStart, stringStart + 1)
             , what = "Unclosed string."
             , explain = NONE
             }
         else if not (check Char.isPrint at s) then
           error
-            { pos = slice (s, s+1)
+            { pos = slice (s, s + 1)
             , what = "Invalid character."
-            , explain = SOME "Strings can only contain printable (visible or \
-                             \whitespace) ASCII characters."
+            , explain =
+                SOME
+                  "Strings can only contain printable (visible or \
+                  \whitespace) ASCII characters."
             }
         else
-          SOME (EndOfChar (s+1))
-
+          SOME (EndOfChar (s + 1))
 
 
       (** Inside a string, immediately after a backslash *)
       and advance_inStringEscapeSequence s (args as {stringStart}) =
         if check LexUtils.isValidSingleEscapeChar at s then
           (** Includes e.g. \t, \n, \", \\, etc. *)
-          SOME (EndOfChar (s+1))
+          SOME (EndOfChar (s + 1))
         else if check LexUtils.isValidFormatEscapeChar at s then
-          advance_inStringFormatEscapeSequence (s+1)
-            { stringStart = stringStart
-            , escapeStart = s-1
-            }
+          advance_inStringFormatEscapeSequence (s + 1)
+            {stringStart = stringStart, escapeStart = s - 1}
         else if is #"^" at s then
-          advance_inStringControlEscapeSequence (s+1) args
+          advance_inStringControlEscapeSequence (s + 1) args
         else if is #"u" at s then
-          advance_inStringFourDigitEscapeSequence (s+1) args
+          advance_inStringFourDigitEscapeSequence (s + 1) args
         else if check LexUtils.isDecDigit at s then
           (** Note the `s` instead of `s+1`... intentional. *)
           advance_inStringThreeDigitEscapeSequence s args
         else if isEndOfFileAt s then
           error
-            { pos = slice (stringStart, stringStart+1)
+            { pos = slice (stringStart, stringStart + 1)
             , what = "Unclosed string."
             , explain = NONE
             }
         else
           error
-            { pos = slice (s-1, s+1)
+            { pos = slice (s - 1, s + 1)
             , what = "Invalid escape sequence."
             , explain = NONE
             }
-
 
 
       (** In a string, expecting to see \ddd
@@ -142,17 +136,19 @@ struct
         *)
       and advance_inStringThreeDigitEscapeSequence s args =
         if
-          check LexUtils.isDecDigit at s andalso
-          check LexUtils.isDecDigit at s+1 andalso
-          check LexUtils.isDecDigit at s+2
+          check LexUtils.isDecDigit at s
+          andalso check LexUtils.isDecDigit at s + 1
+          andalso check LexUtils.isDecDigit at s + 2
         then
-          SOME (EndOfChar (s+3))
+          SOME (EndOfChar (s + 3))
         else
           error
-            { pos = slice (s-1, s)
+            { pos = slice (s - 1, s)
             , what = "Invalid escape sequence"
-            , explain = SOME "Three-digit escape sequences must look like \
-                             \\\DDD where D is a decimal digit."
+            , explain =
+                SOME
+                  "Three-digit escape sequences must look like \
+                  \\\DDD where D is a decimal digit."
             }
 
 
@@ -161,18 +157,20 @@ struct
         *)
       and advance_inStringFourDigitEscapeSequence s args =
         if
-          check LexUtils.isHexDigit at s andalso
-          check LexUtils.isHexDigit at s+1 andalso
-          check LexUtils.isHexDigit at s+2 andalso
-          check LexUtils.isHexDigit at s+3
+          check LexUtils.isHexDigit at s
+          andalso check LexUtils.isHexDigit at s + 1
+          andalso check LexUtils.isHexDigit at s + 2
+          andalso check LexUtils.isHexDigit at s + 3
         then
-          SOME (EndOfChar (s+4))
+          SOME (EndOfChar (s + 4))
         else
           error
-            { pos = slice (s-2, s-1)
+            { pos = slice (s - 2, s - 1)
             , what = "Invalid escape sequence."
-            , explain = SOME "Four-digit escape sequences must look like \
-                             \\\uXXXX where X is a hexadecimal digit."
+            , explain =
+                SOME
+                  "Four-digit escape sequences must look like \
+                  \\\uXXXX where X is a hexadecimal digit."
             }
 
 
@@ -181,40 +179,42 @@ struct
         *)
       and advance_inStringControlEscapeSequence s (args as {stringStart}) =
         if check LexUtils.isValidControlEscapeChar at s then
-          SOME (EndOfChar (s+1))
+          SOME (EndOfChar (s + 1))
         else
           error
-            { pos = slice (s-2, s-1)
+            { pos = slice (s - 2, s - 1)
             , what = "Invalid escape sequence."
-            , explain = SOME
-                "Control escape sequences should look like \\^C where C is \
-                \one of the following characters: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+            , explain =
+                SOME
+                  "Control escape sequences should look like \\^C where C is \
+                  \one of the following characters: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
             }
 
 
       (** Inside a string, expecting to be inside a \f...f\
         * where each f is a format character (space, newline, tab, etc.)
         *)
-      and advance_inStringFormatEscapeSequence s (args as {stringStart, escapeStart}) =
+      and advance_inStringFormatEscapeSequence s
+        (args as {stringStart, escapeStart}) =
         if is backslash at s then
-          SOME (EndOfFormatEscape (s+1))
+          SOME (EndOfFormatEscape (s + 1))
         else if check LexUtils.isValidFormatEscapeChar at s then
-          advance_inStringFormatEscapeSequence (s+1) args
+          advance_inStringFormatEscapeSequence (s + 1) args
         else if isEndOfFileAt s then
           error
-            { pos = slice (escapeStart, escapeStart+1)
+            { pos = slice (escapeStart, escapeStart + 1)
             , what = "Unclosed format escape sequence."
             , explain = NONE
             }
         else
           error
-            { pos = slice (s, s+1)
+            { pos = slice (s, s + 1)
             , what = "Invalid format escape character."
-            , explain = SOME
-                "Formatting escape sequences have to be enclosed by backslashes\
-                \ and should only contain whitespace characters."
+            , explain =
+                SOME
+                  "Formatting escape sequences have to be enclosed by backslashes\
+                  \ and should only contain whitespace characters."
             }
-
 
 
       fun advance_toEndOfString s (args as {stringStart}) =
@@ -223,7 +223,7 @@ struct
         | SOME (EndOfFormatEscape s') => advance_toEndOfString s' args
         | NONE =>
             if is #"\"" at s then
-              s+1
+              s + 1
             else
               raise Error.Error
                 { header = "BUG!"
@@ -232,12 +232,10 @@ struct
                         "Bug found in lexer! Please report on GitHub..."
                     , Error.Paragraph
                         "Lexer.advance_toEndOfString: could not find end of string:"
-                    , Error.SourceReference
-                        (slice (stringStart, stringStart+1))
-                    , Error.Paragraph
-                        "Got up to here:"
-                    , Error.SourceReference
-                        (slice (s, s+1))
+                    , Error.SourceReference (slice
+                        (stringStart, stringStart + 1))
+                    , Error.Paragraph "Got up to here:"
+                    , Error.SourceReference (slice (s, s + 1))
                     ]
                 }
 
@@ -264,107 +262,84 @@ struct
           NONE
         else
           case get s of
-            #"(" =>
-              loop_afterOpenParen (s+1)
-          | #")" =>
-              success (mkr Token.CloseParen (s, s+1))
-          | #"[" =>
-              success (mkr Token.OpenSquareBracket (s, s+1))
-          | #"]" =>
-              success (mkr Token.CloseSquareBracket (s, s+1))
-          | #"{" =>
-              success (mkr Token.OpenCurlyBracket (s, s+1))
-          | #"}" =>
-              success (mkr Token.CloseCurlyBracket (s, s+1))
-          | #"," =>
-              success (mkr Token.Comma (s, s+1))
-          | #";" =>
-              success (mkr Token.Semicolon (s, s+1))
-          | #"_" =>
-              success (mkr Token.Underscore (s, s+1))
+            #"(" => loop_afterOpenParen (s + 1)
+          | #")" => success (mkr Token.CloseParen (s, s + 1))
+          | #"[" => success (mkr Token.OpenSquareBracket (s, s + 1))
+          | #"]" => success (mkr Token.CloseSquareBracket (s, s + 1))
+          | #"{" => success (mkr Token.OpenCurlyBracket (s, s + 1))
+          | #"}" => success (mkr Token.CloseCurlyBracket (s, s + 1))
+          | #"," => success (mkr Token.Comma (s, s + 1))
+          | #";" => success (mkr Token.Semicolon (s, s + 1))
+          | #"_" => success (mkr Token.Underscore (s, s + 1))
           | #"\"" =>
-              let
-                val s' = advance_toEndOfString (s+1) {stringStart = s}
-              in
-                success (mk Token.StringConstant (s, s'))
+              let val s' = advance_toEndOfString (s + 1) {stringStart = s}
+              in success (mk Token.StringConstant (s, s'))
               end
-          | #"~" =>
-              loop_afterTwiddle (s+1)
+          | #"~" => loop_afterTwiddle (s + 1)
           | #"'" =>
-              loop_alphanumId (s+1)
-                { idStart = s
-                , startsPrime = true
-                , longStart = NONE
-                }
-          | #"0" =>
-              loop_afterZero (s+1)
-          | #"." =>
-              loop_afterDot (s+1)
-          | #"*" =>
-              loop_symbolicId (s+1) {idStart = s, longStart = NONE}
+              loop_alphanumId (s + 1)
+                {idStart = s, startsPrime = true, longStart = NONE}
+          | #"0" => loop_afterZero (s + 1)
+          | #"." => loop_afterDot (s + 1)
+          | #"*" => loop_symbolicId (s + 1) {idStart = s, longStart = NONE}
           | #"#" =>
-              if is #"\"" at s+1 then
-                loop_charConstant (s+2)
-              else
-                loop_symbolicId (s+1) {idStart = s, longStart = NONE}
+              if is #"\"" at s + 1 then loop_charConstant (s + 2)
+              else loop_symbolicId (s + 1) {idStart = s, longStart = NONE}
           | c =>
               if LexUtils.isDecDigit c then
-                loop_decIntegerConstant (s+1) {constStart = s}
+                loop_decIntegerConstant (s + 1) {constStart = s}
               else if LexUtils.isSymbolic c then
-                loop_symbolicId (s+1) {idStart = s, longStart = NONE}
+                loop_symbolicId (s + 1) {idStart = s, longStart = NONE}
               else if LexUtils.isLetter c then
-                loop_alphanumId (s+1)
+                loop_alphanumId (s + 1)
                   {idStart = s, startsPrime = false, longStart = NONE}
               else if Char.isSpace c then
-                loop_whitespace {start = s} (s+1)
+                loop_whitespace {start = s} (s + 1)
               else
                 error
-                  { pos = slice (s, s+1)
+                  { pos = slice (s, s + 1)
                   , what = "Unexpected character."
                   , explain = SOME "Perhaps from unsupported character-set?"
                   }
 
 
       and loop_whitespace {start} i =
-        if check Char.isSpace i then
-          loop_whitespace {start=start} (i+1)
-        else
-          success (mk Token.Whitespace (start, i))
+        if check Char.isSpace i then loop_whitespace {start = start} (i + 1)
+        else success (mk Token.Whitespace (start, i))
 
 
       (** #"...
         *   ^
         *)
       and loop_charConstant s =
-        case advance_oneCharInString s {stringStart = s-1} of
+        case advance_oneCharInString s {stringStart = s - 1} of
           SOME s' =>
             if is #"\"" at s' then
-              success (mk Token.CharConstant (s-2, s'+1))
+              success (mk Token.CharConstant (s - 2, s' + 1))
             else
               error
-                { pos = slice (s', s'+1)
+                { pos = slice (s', s' + 1)
                 , what = "Character constant contains more than one character."
                 , explain = NONE
                 }
 
         | NONE =>
             error
-              { pos = slice (s-2, s+1)
+              { pos = slice (s - 2, s + 1)
               , what = "Character constant is empty."
               , explain = NONE
               }
 
 
-
       and loop_afterDot s =
-        if (is #"." at s) andalso (is #"." at s+1) then
-          success (mkr Token.DotDotDot (s-1, s+2))
+        if (is #"." at s) andalso (is #"." at s + 1) then
+          success (mkr Token.DotDotDot (s - 1, s + 2))
         else
           let
-            val huh = if (is #"." at s) then s+1 else s
+            val huh = if (is #"." at s) then s + 1 else s
           in
             error
-              { pos = slice (huh, huh+1)
+              { pos = slice (huh, huh + 1)
               , what = "Unexpected character."
               , explain = SOME "Perhaps you meant: ..."
               }
@@ -373,7 +348,30 @@ struct
 
       and loop_symbolicId s (args as {idStart, longStart}) =
         if check LexUtils.isSymbolic at s then
-          loop_symbolicId (s+1) args
+          loop_symbolicId (s + 1) args
+        else
+          let
+            val srcHere = slice (idStart, s)
+            val tok = Token.Pretoken.reservedOrIdentifier srcHere
+            val isQualified = Option.isSome longStart
+          in
+            if Token.isReserved (Token.fromPre tok) andalso isQualified then
+              error
+                { pos = srcHere
+                , what = "Unexpected reserved symbol."
+                , explain =
+                    SOME "Reserved symbols cannot be used as identifiers."
+                }
+            else if not isQualified then
+              success tok
+            else
+              success (mk Token.LongIdentifier (Option.valOf longStart, s))
+          end
+
+
+      and loop_alphanumId s (args as {idStart, startsPrime, longStart}) =
+        if check LexUtils.isAlphaNumPrimeOrUnderscore at s then
+          loop_alphanumId (s + 1) args
         else
           let
             val srcHere = slice (idStart, s)
@@ -382,73 +380,48 @@ struct
           in
             if
               Token.isReserved (Token.fromPre tok)
-              andalso isQualified
-            then
-              error
-                { pos = srcHere
-                , what = "Unexpected reserved symbol."
-                , explain = SOME "Reserved symbols cannot be used as identifiers."
-                }
-            else if not isQualified then
-              success tok
-            else
-              success (mk Token.LongIdentifier (Option.valOf longStart, s))
-          end
-
-
-
-      and loop_alphanumId s (args as {idStart, startsPrime, longStart}) =
-        if check LexUtils.isAlphaNumPrimeOrUnderscore at s then
-          loop_alphanumId (s+1) args
-        else
-          let
-            val srcHere = slice (idStart, s)
-            val tok = Token.Pretoken.reservedOrIdentifier srcHere
-            val isQualified = Option.isSome longStart
-          in
-            if
-              Token.isReserved (Token.fromPre tok) andalso
-              (isQualified orelse is #"." at s)
+              andalso (isQualified orelse is #"." at s)
             then
               error
                 { pos = srcHere
                 , what = "Unexpected reserved keyword."
-                , explain = SOME "Reserved keywords cannot be used as identifiers."
+                , explain =
+                    SOME "Reserved keywords cannot be used as identifiers."
                 }
-            else if is #"." at s andalso startsPrime then
+            else if
+              is #"." at s andalso startsPrime
+            then
               error
-                { pos = slice (s, s+1)
+                { pos = slice (s, s + 1)
                 , what = "Unexpected dot."
                 , explain = SOME "Qualifiers cannot start with a prime (')"
                 }
-            else if is #"." at s then
-              loop_continueLongIdentifier (s+1)
-                { longStart = if isQualified then longStart else SOME idStart }
-            else if not isQualified then
+            else if
+              is #"." at s
+            then
+              loop_continueLongIdentifier (s + 1)
+                {longStart = if isQualified then longStart else SOME idStart}
+            else if
+              not isQualified
+            then
               success tok
             else
               success (mk Token.LongIdentifier (Option.valOf longStart, s))
           end
 
 
-
       and loop_continueLongIdentifier s {longStart} =
         if check LexUtils.isSymbolic at s then
-          loop_symbolicId (s+1)
-            { idStart = s
-            , longStart = longStart
-            }
+          loop_symbolicId (s + 1) {idStart = s, longStart = longStart}
         else if check LexUtils.isLetter at s then
-          loop_alphanumId (s+1)
-            { idStart = s
-            , startsPrime = false
-            , longStart = longStart
-            }
+          loop_alphanumId (s + 1)
+            {idStart = s, startsPrime = false, longStart = longStart}
         else
           error
-            { pos = slice (s, s+1)
+            { pos = slice (s, s + 1)
             , what = "Unexpected character."
-            , explain = SOME "Identifiers have to start with a letter or symbol."
+            , explain =
+                SOME "Identifiers have to start with a letter or symbol."
             }
 
 
@@ -460,14 +433,13 @@ struct
         *)
       and loop_afterTwiddle s =
         if is #"0" at s then
-          loop_afterTwiddleThenZero (s+1)
+          loop_afterTwiddleThenZero (s + 1)
         else if check LexUtils.isDecDigit at s then
-          loop_decIntegerConstant (s+1) {constStart = s - 1}
+          loop_decIntegerConstant (s + 1) {constStart = s - 1}
         else if check LexUtils.isSymbolic at s then
-          loop_symbolicId (s+1) {idStart = s - 1, longStart = NONE}
+          loop_symbolicId (s + 1) {idStart = s - 1, longStart = NONE}
         else
           success (mk Token.Identifier (s - 1, s))
-
 
 
       (** Comes after "~0"
@@ -475,17 +447,16 @@ struct
         * to first figure out if the integer constant is hex format.
         *)
       and loop_afterTwiddleThenZero s =
-        if is #"x" at s andalso check LexUtils.isHexDigit at s+1 then
-          loop_hexIntegerConstant (s+2) {constStart = s - 2}
+        if is #"x" at s andalso check LexUtils.isHexDigit at s + 1 then
+          loop_hexIntegerConstant (s + 2) {constStart = s - 2}
         else if is #"." at s then
-          loop_realConstantAfterDot (s+1) {constStart = s - 2}
+          loop_realConstantAfterDot (s + 1) {constStart = s - 2}
         else if is #"e" at s orelse is #"E" at s then
-          loop_realConstantAfterExponent (s+1) {constStart = s - 2}
+          loop_realConstantAfterExponent (s + 1) {constStart = s - 2}
         else if check LexUtils.isDecDigit at s then
-          loop_decIntegerConstant (s+1) {constStart = s - 2}
+          loop_decIntegerConstant (s + 1) {constStart = s - 2}
         else
           success (mk Token.IntegerConstant (s - 2, s))
-
 
 
       (** After seeing "0", we're certainly at the beginning of some sort
@@ -493,43 +464,42 @@ struct
         * a word or a real, and if it is hex or decimal format.
         *)
       and loop_afterZero s =
-        if is #"x" at s andalso check LexUtils.isHexDigit at s+1 then
-          loop_hexIntegerConstant (s+2) {constStart = s - 1}
+        if is #"x" at s andalso check LexUtils.isHexDigit at s + 1 then
+          loop_hexIntegerConstant (s + 2) {constStart = s - 1}
         else if is #"w" at s then
-          loop_afterZeroDubya (s+1)
+          loop_afterZeroDubya (s + 1)
         else if is #"." at s then
-          loop_realConstantAfterDot (s+1) {constStart = s - 1}
+          loop_realConstantAfterDot (s + 1) {constStart = s - 1}
         else if is #"e" at s orelse is #"E" at s then
-          loop_realConstantAfterExponent (s+1) {constStart = s - 1}
+          loop_realConstantAfterExponent (s + 1) {constStart = s - 1}
         else if check LexUtils.isDecDigit at s then
-          loop_decIntegerConstant (s+1) {constStart = s - 1}
+          loop_decIntegerConstant (s + 1) {constStart = s - 1}
         else
-          success (mk Token.IntegerConstant (s-1, s))
-
+          success (mk Token.IntegerConstant (s - 1, s))
 
 
       and loop_decIntegerConstant s (args as {constStart}) =
         if check LexUtils.isDecDigit at s then
-          loop_decIntegerConstant (s+1) args
+          loop_decIntegerConstant (s + 1) args
         else if is #"." at s then
-          loop_realConstantAfterDot (s+1) args
+          loop_realConstantAfterDot (s + 1) args
         else if is #"e" at s orelse is #"E" at s then
-          loop_realConstantAfterExponent (s+1) args
+          loop_realConstantAfterExponent (s + 1) args
         else
           success (mk Token.IntegerConstant (constStart, s))
-
 
 
       (** Immediately after the dot, we need to see at least one decimal digit *)
       and loop_realConstantAfterDot s (args as {constStart}) =
         if check LexUtils.isDecDigit at s then
-          loop_realConstant (s+1) args
+          loop_realConstant (s + 1) args
         else
           error
             { pos = slice (constStart, s)
             , what = "Invalid real constant."
-            , explain = SOME
-                "After the dot, there needs to be at least one decimal digit."
+            , explain =
+                SOME
+                  "After the dot, there needs to be at least one decimal digit."
             }
 
 
@@ -539,12 +509,11 @@ struct
         *)
       and loop_realConstant s (args as {constStart}) =
         if check LexUtils.isDecDigit at s then
-          loop_realConstant (s+1) args
-        else if  is #"E" at s  orelse  is #"e" at s  then
-          loop_realConstantAfterExponent (s+1) args
+          loop_realConstant (s + 1) args
+        else if is #"E" at s orelse is #"e" at s then
+          loop_realConstantAfterExponent (s + 1) args
         else
           success (mk Token.RealConstant (constStart, s))
-
 
 
       (** Immediately after the "E" or "e", there might be a twiddle,
@@ -553,39 +522,29 @@ struct
       and loop_realConstantAfterExponent s {constStart} =
         let
           fun walkThroughDigits i =
-            if check LexUtils.isDecDigit at i then
-              walkThroughDigits (i+1)
-            else
-              i
-          val s' = walkThroughDigits (if is #"~" at s then s+1 else s)
+            if check LexUtils.isDecDigit at i then walkThroughDigits (i + 1)
+            else i
+          val s' = walkThroughDigits (if is #"~" at s then s + 1 else s)
         in
           success (mk Token.RealConstant (constStart, s'))
         end
 
 
-
       and loop_hexIntegerConstant s (args as {constStart}) =
         if check LexUtils.isHexDigit at s then
-          loop_hexIntegerConstant (s+1) args
+          loop_hexIntegerConstant (s + 1) args
         else
           success (mk Token.IntegerConstant (constStart, s))
 
 
-
       and loop_decWordConstant s (args as {constStart}) =
-        if check LexUtils.isDecDigit at s then
-          loop_decWordConstant (s+1) args
-        else
-          success (mk Token.WordConstant (constStart, s))
-
+        if check LexUtils.isDecDigit at s then loop_decWordConstant (s + 1) args
+        else success (mk Token.WordConstant (constStart, s))
 
 
       and loop_hexWordConstant s (args as {constStart}) =
-        if check LexUtils.isHexDigit at s then
-          loop_hexWordConstant (s+1) args
-        else
-          success (mk Token.WordConstant (constStart, s))
-
+        if check LexUtils.isHexDigit at s then loop_hexWordConstant (s + 1) args
+        else success (mk Token.WordConstant (constStart, s))
 
 
       (** Comes after "0w"
@@ -597,13 +556,12 @@ struct
         *   0wx       -- integer constant 0 followed by alphanum-id "wx"
         *)
       and loop_afterZeroDubya s =
-        if is #"x" at s andalso check LexUtils.isHexDigit at s+1 then
-          loop_hexWordConstant (s+2) {constStart = s - 2}
+        if is #"x" at s andalso check LexUtils.isHexDigit at s + 1 then
+          loop_hexWordConstant (s + 2) {constStart = s - 2}
         else if check LexUtils.isDecDigit at s then
-          loop_decWordConstant (s+1) {constStart = s - 2}
+          loop_decWordConstant (s + 1) {constStart = s - 2}
         else
           success (mk Token.IntegerConstant (s - 2, s - 1))
-
 
 
       (** An open-paren could just be a normal paren, or it could be the
@@ -611,10 +569,9 @@ struct
         *)
       and loop_afterOpenParen s =
         if is #"*" at s then
-          loop_inComment (s+1) {commentStart = s - 1, nesting = 1}
+          loop_inComment (s + 1) {commentStart = s - 1, nesting = 1}
         else
           success (mkr Token.OpenParen (s - 1, s))
-
 
 
       (** Inside a comment that started at `commentStart`
@@ -623,24 +580,26 @@ struct
       and loop_inComment s {commentStart, nesting} =
         if nesting = 0 then
           success (mk Token.Comment (commentStart, s))
-        else if is #"(" at s andalso is #"*" at s+1 then
-          loop_inComment (s+2) {commentStart=commentStart, nesting=nesting+1}
-        else if is #"*" at s andalso is #")" at s+1 then
-          loop_inComment (s+2) {commentStart=commentStart, nesting=nesting-1}
+        else if is #"(" at s andalso is #"*" at s + 1 then
+          loop_inComment (s + 2)
+            {commentStart = commentStart, nesting = nesting + 1}
+        else if is #"*" at s andalso is #")" at s + 1 then
+          loop_inComment (s + 2)
+            {commentStart = commentStart, nesting = nesting - 1}
         else if isEndOfFileAt s then
           error
-            { pos = slice (commentStart, commentStart+2)
+            { pos = slice (commentStart, commentStart + 2)
             , what = "Unclosed comment."
             , explain = NONE
             }
         else
-          loop_inComment (s+1) {commentStart=commentStart, nesting=nesting}
+          loop_inComment (s + 1)
+            {commentStart = commentStart, nesting = nesting}
 
 
     in
       loop_topLevel startOffset
     end
-
 
 
   fun tokens src =
@@ -660,10 +619,8 @@ struct
           finish acc
         else
           case next (Source.drop src offset) of
-            NONE =>
-              finish acc
-          | SOME tok =>
-              loop (tok :: acc) (tokEndOffset tok)
+            NONE => finish acc
+          | SOME tok => loop (tok :: acc) (tokEndOffset tok)
     in
       loop [] startOffset
     end

--- a/src/lex/Token.sml
+++ b/src/lex/Token.sml
@@ -273,8 +273,8 @@ struct
     let
       val src1 = getSource tok1
       val src2 = getSource tok2
-      val {line=end1, ...} = Source.absoluteEnd (getSource tok1)
-      val {line=start2, ...} = Source.absoluteStart (getSource tok2)
+      val {line = end1, ...} = Source.absoluteEnd (getSource tok1)
+      val {line = start2, ...} = Source.absoluteStart (getSource tok2)
     in
       if FilePath.sameFile (Source.fileName src1, Source.fileName src2) then
         start2 - end1
@@ -283,10 +283,8 @@ struct
     end
 
   fun toString tok =
-    let
-      val src = getSource tok
-    in
-      CharVector.tabulate (Source.length src, Source.nth src)
+    let val src = getSource tok
+    in CharVector.tabulate (Source.length src, Source.nth src)
     end
 
   fun tryReserved src =
@@ -347,8 +345,7 @@ struct
       | "structure" => r Structure
       | "where" => r Where
 
-      | other => NONE
-          (* (print ("not reserved: " ^ other ^ "\n"); NONE) *)
+      | other => NONE (* (print ("not reserved: " ^ other ^ "\n"); NONE) *)
     end
 
   fun reservedToString rc =
@@ -441,8 +438,7 @@ struct
       Whitespace => true
     | _ => false
 
-  fun isCommentOrWhitespace tok =
-    isComment tok orelse isWhitespace tok
+  fun isCommentOrWhitespace tok = isComment tok orelse isWhitespace tok
 
   fun isComma tok =
     case getClass tok of
@@ -460,10 +456,8 @@ struct
     | _ => false
 
   fun isStar tok =
-    let
-      val src = getSource tok
-    in
-      Source.length src = 1 andalso Source.nth src 0 = #"*"
+    let val src = getSource tok
+    in Source.length src = 1 andalso Source.nth src 0 = #"*"
     end
 
   fun isOpenParen tok =
@@ -508,8 +502,7 @@ struct
   fun isSymbolicIdentifier tok =
     let
       val src = getSource tok
-      val isSymb =
-        LexUtils.isSymbolic (Source.nth src (Source.length src - 1))
+      val isSymb = LexUtils.isSymbolic (Source.nth src (Source.length src - 1))
     in
       case getClass tok of
         Identifier => isSymb
@@ -551,8 +544,7 @@ struct
         not (isStar tok) andalso (Source.nth (getSource tok) 0 <> #"'")
     | _ => false
 
-  fun isMaybeLongTyCon tok =
-    isTyCon tok orelse isLongIdentifier tok
+  fun isMaybeLongTyCon tok = isTyCon tok orelse isLongIdentifier tok
 
   (** SML permits ints, strings, words, and chars as constants in patterns,
     * but NOT reals.
@@ -580,9 +572,8 @@ struct
     in
       case getClass tok of
         IntegerConstant =>
-          Source.length src > 2 andalso
-          Source.nth src 0 = #"0" andalso
-          Source.nth src 1 = #"x"
+          Source.length src > 2 andalso Source.nth src 0 = #"0"
+          andalso Source.nth src 1 = #"x"
       | _ => false
     end
 
@@ -611,47 +602,31 @@ struct
     , Local
     ]
 
-  val strDecStartTokens =
-    [ Structure
-    , Local
-    ]
+  val strDecStartTokens = [Structure, Local]
 
-  val sigDecStartTokens =
-    [ Signature
-    ]
+  val sigDecStartTokens = [Signature]
 
   val sigSpecStartTokens =
-    [ Val
-    , Type
-    , Eqtype
-    , Datatype
-    , Exception
-    , Structure
-    , Include
-    ]
+    [Val, Type, Eqtype, Datatype, Exception, Structure, Include]
 
   fun isDecStartToken tok =
     case getClass tok of
-      Reserved rc =>
-        List.exists (fn rc' => rc = rc') decStartTokens
+      Reserved rc => List.exists (fn rc' => rc = rc') decStartTokens
     | _ => false
 
   fun isStrDecStartToken tok =
     case getClass tok of
-      Reserved rc =>
-        List.exists (fn rc' => rc = rc') strDecStartTokens
+      Reserved rc => List.exists (fn rc' => rc = rc') strDecStartTokens
     | _ => false
 
   fun isSigDecStartToken tok =
     case getClass tok of
-      Reserved rc =>
-        List.exists (fn rc' => rc = rc') sigDecStartTokens
+      Reserved rc => List.exists (fn rc' => rc = rc') sigDecStartTokens
     | _ => false
 
   fun isSigSpecStartToken tok =
     case getClass tok of
-      Reserved rc =>
-        List.exists (fn rc' => rc = rc') sigSpecStartTokens
+      Reserved rc => List.exists (fn rc' => rc = rc') sigSpecStartTokens
     | _ => false
 
   fun classToString class =
@@ -690,12 +665,7 @@ struct
       Comment => false
     | Reserved rc =>
         List.exists (fn rc' => rc = rc')
-          [ OpenParen
-          , OpenSquareBracket
-          , OpenCurlyBracket
-          , Underscore
-          , Op
-          ]
+          [OpenParen, OpenSquareBracket, OpenCurlyBracket, Underscore, Op]
     | _ => true
 
 
@@ -703,11 +673,8 @@ struct
     * the current expression and pop up to the previous context.
     *)
   fun endsCurrentExp tok =
-    isDecStartToken tok
-    orelse
-    isStrDecStartToken tok
-    orelse
-    isSigDecStartToken tok
+    isDecStartToken tok orelse isStrDecStartToken tok
+    orelse isSigDecStartToken tok
     orelse
     case getClass tok of
       Reserved rc =>
@@ -729,54 +696,40 @@ struct
     | _ => false
 
 
-
-  fun makeGroup (s: pretoken Seq.t): token Seq.t =
+  fun makeGroup (s: pretoken Seq.t) : token Seq.t =
     Seq.tabulate (fn i => {idx = i, context = s}) (Seq.length s)
 
   fun fromPre (t: pretoken) =
     Seq.nth (makeGroup (Seq.singleton t)) 0
 
-  fun nextToken ({idx=i, context}: token) =
-    if i+1 < Seq.length context then
-      SOME {idx = i+1, context = context}
-    else
-      NONE
+  fun nextToken ({idx = i, context}: token) =
+    if i + 1 < Seq.length context then SOME {idx = i + 1, context = context}
+    else NONE
 
-  fun prevToken ({idx=i, context}: token) =
-    if i > 0 then
-      SOME {idx = i-1, context = context}
-    else
-      NONE
+  fun prevToken ({idx = i, context}: token) =
+    if i > 0 then SOME {idx = i - 1, context = context} else NONE
 
   fun prevTokenNotCommentOrWhitespace tok =
     case prevToken tok of
       NONE => NONE
     | SOME t' =>
-        if isCommentOrWhitespace t' then
-          prevTokenNotCommentOrWhitespace t'
-        else
-          SOME t'
+        if isCommentOrWhitespace t' then prevTokenNotCommentOrWhitespace t'
+        else SOME t'
 
   fun nextTokenNotCommentOrWhitespace tok =
     case nextToken tok of
       NONE => NONE
     | SOME t' =>
-        if isCommentOrWhitespace t' then
-          nextTokenNotCommentOrWhitespace t'
-        else
-          SOME t'
+        if isCommentOrWhitespace t' then nextTokenNotCommentOrWhitespace t'
+        else SOME t'
 
   fun commentsOrWhitespaceBefore tok =
     let
       fun loop acc t =
         case prevToken t of
           SOME t' =>
-            if isCommentOrWhitespace t' then
-              loop (t' :: acc) t'
-            else
-              acc
-        | NONE =>
-            acc
+            if isCommentOrWhitespace t' then loop (t' :: acc) t' else acc
+        | NONE => acc
     in
       Seq.fromList (loop [] tok)
     end
@@ -786,12 +739,8 @@ struct
       fun loop acc t =
         case nextToken t of
           SOME t' =>
-            if isCommentOrWhitespace t' then
-              loop (t' :: acc) t'
-            else
-              acc
-        | NONE =>
-            acc
+            if isCommentOrWhitespace t' then loop (t' :: acc) t' else acc
+        | NONE => acc
     in
       Seq.fromRevList (loop [] tok)
     end
@@ -816,14 +765,10 @@ struct
       fun loop acc t =
         case prevToken t of
           SOME t' =>
-            if isWhitespace t' then
-              loop acc t'
-            else if isComment t' then
-              loop (t' :: acc) t'
-            else
-              acc
-        | NONE =>
-            acc
+            if isWhitespace t' then loop acc t'
+            else if isComment t' then loop (t' :: acc) t'
+            else acc
+        | NONE => acc
     in
       Seq.fromList (loop [] tok)
     end
@@ -834,14 +779,10 @@ struct
       fun loop acc t =
         case nextToken t of
           SOME t' =>
-            if isWhitespace t' then
-              loop acc t'
-            else if isComment t' then
-              loop (t' :: acc) t'
-            else
-              acc
-        | NONE =>
-            acc
+            if isWhitespace t' then loop acc t'
+            else if isComment t' then loop (t' :: acc) t'
+            else acc
+        | NONE => acc
     in
       Seq.fromRevList (loop [] tok)
     end

--- a/src/parse-mlb/MLBAst.sml
+++ b/src/parse-mlb/MLBAst.sml
@@ -3,7 +3,4 @@
   * See the file LICENSE for details.
   *)
 
-structure MLBAst =
-struct
-  open MLBAstType
-end
+structure MLBAst = struct open MLBAstType end

--- a/src/parse-mlb/MLBAstType.sml
+++ b/src/parse-mlb/MLBAstType.sml
@@ -21,11 +21,7 @@ struct
       }
 
   (** bas basdec end *)
-  | BasEnd of
-      { bas: MLBToken.t
-      , basdec: basdec
-      , endd: MLBToken.t
-      }
+  | BasEnd of {bas: MLBToken.t, basdec: basdec, endd: MLBToken.t}
 
 
   and basdec =
@@ -33,31 +29,18 @@ struct
     DecEmpty
 
   (** basdec [;] basdec *)
-  | DecMultiple of
-      { elems: basdec Seq.t
-      , delims: MLBToken.t option Seq.t
-      }
+  | DecMultiple of {elems: basdec Seq.t, delims: MLBToken.t option Seq.t}
 
   (** path/to/file.mlb *)
-  | DecPathMLB of
-      { path: FilePath.t
-      , token: MLBToken.t
-      }
+  | DecPathMLB of {path: FilePath.t, token: MLBToken.t}
 
   (** path/to/file.{sml,sig,fun} *)
-  | DecPathSML of
-      { path: FilePath.t
-      , token: MLBToken.t
-      }
+  | DecPathSML of {path: FilePath.t, token: MLBToken.t}
 
   (** basis basid = basexp [and ...] *)
   | DecBasis of
       { basis: MLBToken.t
-      , elems:
-          { basid: MLBToken.t
-          , eq: MLBToken.t
-          , basexp: basexp
-          } Seq.t
+      , elems: {basid: MLBToken.t, eq: MLBToken.t, basexp: basexp} Seq.t
       (** 'and' delims *)
       , delims: MLBToken.t Seq.t
       }
@@ -72,20 +55,14 @@ struct
       }
 
   (** open basid ... basid *)
-  | DecOpen of
-      { openn: MLBToken.t
-      , elems: MLBToken.t Seq.t
-      }
+  | DecOpen of {openn: MLBToken.t, elems: MLBToken.t Seq.t}
 
   (** structure strid [= strid] [and ...] *)
   | DecStructure of
       { structuree: MLBToken.t
       , elems:
           { strid: MLBToken.t
-          , eqstrid:
-              { eq: MLBToken.t
-              , strid: MLBToken.t
-              } option
+          , eqstrid: {eq: MLBToken.t, strid: MLBToken.t} option
           } Seq.t
       (** 'and' delimiters *)
       , delims: MLBToken.t Seq.t
@@ -96,10 +73,7 @@ struct
       { signaturee: MLBToken.t
       , elems:
           { sigid: MLBToken.t
-          , eqsigid:
-              { eq: MLBToken.t
-              , sigid: MLBToken.t
-              } option
+          , eqsigid: {eq: MLBToken.t, sigid: MLBToken.t} option
           } Seq.t
       (** 'and' delimiters *)
       , delims: MLBToken.t Seq.t
@@ -110,10 +84,7 @@ struct
       { functorr: MLBToken.t
       , elems:
           { funid: MLBToken.t
-          , eqfunid:
-              { eq: MLBToken.t
-              , funid: MLBToken.t
-              } option
+          , eqfunid: {eq: MLBToken.t, funid: MLBToken.t} option
           } Seq.t
       (** 'and' delimiters *)
       , delims: MLBToken.t Seq.t

--- a/src/parse-mlb/MLBParser.sml
+++ b/src/parse-mlb/MLBParser.sml
@@ -22,111 +22,123 @@ struct
     i < Seq.length toks andalso f (Seq.nth toks i)
 
   fun isReserved_ toks rc i =
-    check_ toks (fn t =>
-      case MLBToken.getClass t of
-        MLBToken.Reserved rc' => rc = rc'
-      | _ => false)
-    i
+    check_ toks
+      (fn t =>
+         case MLBToken.getClass t of
+           MLBToken.Reserved rc' => rc = rc'
+         | _ => false) i
 
   fun isSMLReserved_ toks rc i =
-    check_ toks (fn t =>
-      case MLBToken.getClass t of
-        MLBToken.SML (Token.Reserved rc') => rc = rc'
-      | _ => false)
-    i
+    check_ toks
+      (fn t =>
+         case MLBToken.getClass t of
+           MLBToken.SML (Token.Reserved rc') => rc = rc'
+         | _ => false) i
 
 
   fun nyi_ toks fname i =
     if i >= Seq.length toks then
-      raise Error.Error (Error.lineError
-        { header = "ERROR: NOT YET IMPLEMENTED"
-        , pos = MLBToken.getSource (Seq.nth toks (Seq.length toks - 1))
-        , what = "Unexpected EOF after token."
-        , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
-        })
+      raise Error.Error
+        (Error.lineError
+           { header = "ERROR: NOT YET IMPLEMENTED"
+           , pos = MLBToken.getSource (Seq.nth toks (Seq.length toks - 1))
+           , what = "Unexpected EOF after token."
+           , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
+           })
     else if i >= 0 then
-      raise Error.Error (Error.lineError
-        { header = "ERROR: NOT YET IMPLEMENTED"
-        , pos = MLBToken.getSource (Seq.nth toks i)
-        , what = "Unexpected token."
-        , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
-        })
+      raise Error.Error
+        (Error.lineError
+           { header = "ERROR: NOT YET IMPLEMENTED"
+           , pos = MLBToken.getSource (Seq.nth toks i)
+           , what = "Unexpected token."
+           , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
+           })
     else
       raise Fail ("Bug in parser " ^ fname ^ ": position out of bounds??")
 
 
   fun parse_SMLReserved toks rc i =
     if isSMLReserved_ toks rc i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what =
-            "Unexpected token. Expected to see "
-            ^ "'" ^ Token.reservedToString rc ^ "'"
+            "Unexpected token. Expected to see " ^ "'"
+            ^ Token.reservedToString rc ^ "'"
         , explain = NONE
         }
 
 
   fun checkSML toks f i =
-    i < Seq.length toks andalso
+    i < Seq.length toks
+    andalso
     case MLBToken.getClass (Seq.nth toks i) of
       MLBToken.SML c =>
-        f (Token.fromPre (Token.Pretoken.make (MLBToken.getSource (Seq.nth toks i)) c))
+        f (Token.fromPre
+          (Token.Pretoken.make (MLBToken.getSource (Seq.nth toks i)) c))
     | _ => false
 
 
   fun parse_strid toks i =
     if checkSML toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected structure identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun parse_sigid toks i =
     if checkSML toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected signature identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun parse_funid toks i =
     if checkSML toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected functor identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun parse_basid toks i =
     if checkSML toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected basis identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun parse_stringConstant toks i =
     if checkSML toks Token.isStringConstant i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
@@ -147,19 +159,13 @@ struct
           val (i, elem) = parseElem i
           val elems = elem :: elems
         in
-          if isReserved delim i then
-            loop elems (tok i :: delims) (i+1)
-          else
-            (i, elems, delims)
+          if isReserved delim i then loop elems (tok i :: delims) (i + 1)
+          else (i, elems, delims)
         end
 
       val (i, elems, delims) = loop [] [] i
     in
-      ( i
-      , { elems = Seq.fromRevList elems
-        , delims = Seq.fromRevList delims
-        }
-      )
+      (i, {elems = Seq.fromRevList elems, delims = Seq.fromRevList delims})
     end
 
 
@@ -167,9 +173,12 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = check_ toks f i
-      fun isReserved rc i = isReserved_ toks rc i
-      fun isSMLReserved rc i = isSMLReserved_ toks rc i
+      fun check f i =
+        check_ toks f i
+      fun isReserved rc i =
+        isReserved_ toks rc i
+      fun isSMLReserved rc i =
+        isSMLReserved_ toks rc i
 
 
       (** bas basdec end
@@ -180,13 +189,7 @@ struct
           val (i, basdec) = basdec toks i
           val (i, endd) = parse_SMLReserved toks Token.End i
         in
-          ( i
-          , MLBAst.BasEnd
-              { bas = bas
-              , basdec = basdec
-              , endd = endd
-              }
-          )
+          (i, MLBAst.BasEnd {bas = bas, basdec = basdec, endd = endd})
         end
 
 
@@ -214,11 +217,11 @@ struct
 
       and parse_basexp i =
         if checkSML toks Token.isStrIdentifier i then
-          (i+1, MLBAst.Ident (tok i))
+          (i + 1, MLBAst.Ident (tok i))
         else if isReserved MLBToken.Bas i then
-          parse_bas (tok i) (i+1)
+          parse_bas (tok i) (i + 1)
         else if isSMLReserved Token.Let i then
-          parse_let (tok i) (i+1)
+          parse_let (tok i) (i + 1)
         else
           ParserUtils.error
             { pos = MLBToken.getSource (tok i)
@@ -235,26 +238,26 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = check_ toks f i
-      fun isReserved rc i = isReserved_ toks rc i
-      fun isSMLReserved rc i = isSMLReserved_ toks rc i
+      fun check f i =
+        check_ toks f i
+      fun isReserved rc i =
+        isReserved_ toks rc i
+      fun isSMLReserved rc i =
+        isSMLReserved_ toks rc i
 
 
       (** not yet implemented *)
-      fun nyi fname i = nyi_ toks fname i
+      fun nyi fname i =
+        nyi_ toks fname i
 
 
       fun makeSMLPath pathtok pathstr =
         MLBAst.DecPathSML
-          { token = pathtok
-          , path = FilePath.fromUnixPath pathstr
-          }
+          {token = pathtok, path = FilePath.fromUnixPath pathstr}
 
       fun makeMLBPath pathtok pathstr =
         MLBAst.DecPathMLB
-          { token = pathtok
-          , path = FilePath.fromUnixPath pathstr
-          }
+          {token = pathtok, path = FilePath.fromUnixPath pathstr}
 
 
       (**  "path.{sml,mlb,...}"
@@ -273,18 +276,17 @@ struct
           val n = Source.length thisSrc
           val _ =
             if
-              n >= 2 andalso
-              Source.nth thisSrc 0 = #"\"" andalso
-              Source.nth thisSrc (n - 1) = #"\""
-            then
-              ()
-            else
-              raise Fail "MLBParser bug! see parse_decPathFromString: fail 1"
+              n >= 2 andalso Source.nth thisSrc 0 = #"\""
+              andalso Source.nth thisSrc (n - 1) = #"\""
+            then ()
+            else raise Fail "MLBParser bug! see parse_decPathFromString: fail 1"
 
-          val pathstr = Source.toString (Source.slice thisSrc (1, n-2))
+          val pathstr = Source.toString (Source.slice thisSrc (1, n - 2))
 
-          fun mlbCase () = (i+1, makeMLBPath thisTok pathstr)
-          fun smlCase () = (i+1, makeSMLPath thisTok pathstr)
+          fun mlbCase () =
+            (i + 1, makeMLBPath thisTok pathstr)
+          fun smlCase () =
+            (i + 1, makeSMLPath thisTok pathstr)
         in
           case OS.Path.ext pathstr of
             SOME "mlb" => mlbCase ()
@@ -311,22 +313,14 @@ struct
               val (i, eq) = parse_SMLReserved toks Token.Equal i
               val (i, basexp) = basexp toks i
             in
-              (i, {basid=basid, eq=eq, basexp=basexp})
+              (i, {basid = basid, eq = eq, basexp = basexp})
             end
 
           val (i, {elems, delims}) =
-            parse_oneOrMoreDelimitedBySMLReserved
-              toks
-              {parseElem = parseElem, delim = Token.And}
-              i
+            parse_oneOrMoreDelimitedBySMLReserved toks
+              {parseElem = parseElem, delim = Token.And} i
         in
-          ( i
-          , MLBAst.DecBasis
-              { basis = basis
-              , elems = elems
-              , delims = delims
-              }
-          )
+          (i, MLBAst.DecBasis {basis = basis, elems = elems, delims = delims})
         end
 
 
@@ -337,16 +331,9 @@ struct
         let
           val (i, elems) =
             ParserCombinators.oneOrMoreWhile
-              (checkSML toks Token.isStrIdentifier)
-              (parse_basid toks)
-              i
+              (checkSML toks Token.isStrIdentifier) (parse_basid toks) i
         in
-          ( i
-          , MLBAst.DecOpen
-              { openn = openn
-              , elems = elems
-              }
-          )
+          (i, MLBAst.DecOpen {openn = openn, elems = elems})
         end
 
 
@@ -363,7 +350,7 @@ struct
                   (i, NONE)
                 else
                   let
-                    val (i, eq) = (i+1, tok i)
+                    val (i, eq) = (i + 1, tok i)
                     val (i, strid) = parse_strid toks i
                   in
                     (i, SOME {eq = eq, strid = strid})
@@ -373,17 +360,12 @@ struct
             end
 
           val (i, {elems, delims}) =
-            parse_oneOrMoreDelimitedBySMLReserved
-              toks
-              {parseElem = parseElem, delim = Token.And}
-              i
+            parse_oneOrMoreDelimitedBySMLReserved toks
+              {parseElem = parseElem, delim = Token.And} i
         in
           ( i
           , MLBAst.DecStructure
-              { structuree = structuree
-              , elems = elems
-              , delims = delims
-              }
+              {structuree = structuree, elems = elems, delims = delims}
           )
         end
 
@@ -401,7 +383,7 @@ struct
                   (i, NONE)
                 else
                   let
-                    val (i, eq) = (i+1, tok i)
+                    val (i, eq) = (i + 1, tok i)
                     val (i, sigid) = parse_sigid toks i
                   in
                     (i, SOME {eq = eq, sigid = sigid})
@@ -411,17 +393,12 @@ struct
             end
 
           val (i, {elems, delims}) =
-            parse_oneOrMoreDelimitedBySMLReserved
-              toks
-              {parseElem = parseElem, delim = Token.And}
-              i
+            parse_oneOrMoreDelimitedBySMLReserved toks
+              {parseElem = parseElem, delim = Token.And} i
         in
           ( i
           , MLBAst.DecSignature
-              { signaturee = signaturee
-              , elems = elems
-              , delims = delims
-              }
+              {signaturee = signaturee, elems = elems, delims = delims}
           )
         end
 
@@ -439,7 +416,7 @@ struct
                   (i, NONE)
                 else
                   let
-                    val (i, eq) = (i+1, tok i)
+                    val (i, eq) = (i + 1, tok i)
                     val (i, funid) = parse_funid toks i
                   in
                     (i, SOME {eq = eq, funid = funid})
@@ -449,17 +426,12 @@ struct
             end
 
           val (i, {elems, delims}) =
-            parse_oneOrMoreDelimitedBySMLReserved
-              toks
-              {parseElem = parseElem, delim = Token.And}
-              i
+            parse_oneOrMoreDelimitedBySMLReserved toks
+              {parseElem = parseElem, delim = Token.And} i
         in
           ( i
           , MLBAst.DecFunctor
-              { functorr = functorr
-              , elems = elems
-              , delims = delims
-              }
+              {functorr = functorr, elems = elems, delims = delims}
           )
         end
 
@@ -471,8 +443,7 @@ struct
         let
           val (i, annotations) =
             ParserCombinators.oneOrMoreWhile
-              (checkSML toks Token.isStringConstant)
-              (parse_stringConstant toks)
+              (checkSML toks Token.isStringConstant) (parse_stringConstant toks)
               i
 
           val (i, inn) = parse_SMLReserved toks Token.In i
@@ -515,31 +486,31 @@ struct
 
       and parse_exactlyOneDec i =
         if check MLBToken.isSMLPath i then
-          ( i+1
+          ( i + 1
           , makeSMLPath (tok i) (Source.toString (MLBToken.getSource (tok i)))
           )
         else if check MLBToken.isMLBPath i then
-          ( i+1
+          ( i + 1
           , makeMLBPath (tok i) (Source.toString (MLBToken.getSource (tok i)))
           )
         else if check MLBToken.isStringConstant i then
           parse_decPathFromString i
         else if isReserved MLBToken.UnderscorePrim i then
-          (i+1, MLBAst.DecUnderscorePrim (tok i))
+          (i + 1, MLBAst.DecUnderscorePrim (tok i))
         else if isReserved MLBToken.Basis i then
-          parse_decBasis (tok i) (i+1)
+          parse_decBasis (tok i) (i + 1)
         else if isReserved MLBToken.Ann i then
-          parse_decAnn (tok i) (i+1)
+          parse_decAnn (tok i) (i + 1)
         else if isSMLReserved Token.Open i then
-          parse_decOpen (tok i) (i+1)
+          parse_decOpen (tok i) (i + 1)
         else if isSMLReserved Token.Local i then
-          parse_decLocal (tok i) (i+1)
+          parse_decLocal (tok i) (i + 1)
         else if isSMLReserved Token.Structure i then
-          parse_decStructure (tok i) (i+1)
+          parse_decStructure (tok i) (i + 1)
         else if isSMLReserved Token.Signature i then
-          parse_decSignature (tok i) (i+1)
+          parse_decSignature (tok i) (i + 1)
         else if isSMLReserved Token.Functor i then
-          parse_decFunctor (tok i) (i+1)
+          parse_decFunctor (tok i) (i + 1)
         else
           ParserUtils.error
             { pos = MLBToken.getSource (tok i)
@@ -551,47 +522,31 @@ struct
       and parse_dec i =
         let
           fun parse_maybeSemicolon i =
-            if isSMLReserved Token.Semicolon i then
-              (i+1, SOME (tok i))
-            else
-              (i, NONE)
+            if isSMLReserved Token.Semicolon i then (i + 1, SOME (tok i))
+            else (i, NONE)
 
-          fun continue i =
-            check MLBToken.isBasDecStartToken i
+          fun continue i = check MLBToken.isBasDecStartToken i
 
           (** While we see a basdec start-token, parse pairs of
             *   (dec, semicolon option)
             *)
           val (i, basdecs) =
-            ParserCombinators.zeroOrMoreWhile
-              continue
-              (ParserCombinators.two
-                ( parse_exactlyOneDec
-                , parse_maybeSemicolon
-                ))
+            ParserCombinators.zeroOrMoreWhile continue
+              (ParserCombinators.two (parse_exactlyOneDec, parse_maybeSemicolon))
               i
 
           fun makeDecMultiple () =
             MLBAst.DecMultiple
-              { elems = Seq.map #1 basdecs
-              , delims = Seq.map #2 basdecs
-              }
+              {elems = Seq.map #1 basdecs, delims = Seq.map #2 basdecs}
 
           val result =
             case Seq.length basdecs of
-              0 =>
-                MLBAst.DecEmpty
+              0 => MLBAst.DecEmpty
             | 1 =>
-                let
-                  val (dec, semicolon) = Seq.nth basdecs 0
-                in
-                  if isSome semicolon then
-                    makeDecMultiple ()
-                  else
-                    dec
+                let val (dec, semicolon) = Seq.nth basdecs 0
+                in if isSome semicolon then makeDecMultiple () else dec
                 end
-            | _ =>
-                makeDecMultiple ()
+            | _ => makeDecMultiple ()
         in
           (i, result)
         end
@@ -604,17 +559,20 @@ struct
   fun parse src =
     let
       val toksWithComments = MLBLexer.tokens src
-      val toks = Seq.filter (not o MLBToken.isCommentOrWhitespace) toksWithComments
+      val toks =
+        Seq.filter (not o MLBToken.isCommentOrWhitespace) toksWithComments
 
       val (i, basdec) = basdec toks 0
 
       val _ =
-        if i >= Seq.length toks then () else
-        ParserUtils.error
-          { pos = MLBToken.getSource (Seq.nth toks i)
-          , what = "Unexpected token."
-          , explain = SOME "Invalid start of basis declaration!"
-          }
+        if i >= Seq.length toks then
+          ()
+        else
+          ParserUtils.error
+            { pos = MLBToken.getSource (Seq.nth toks i)
+            , what = "Unexpected token."
+            , explain = SOME "Invalid start of basis declaration!"
+            }
     in
       MLBAst.Ast basdec
     end

--- a/src/parse/ExpPatRestriction.sml
+++ b/src/parse/ExpPatRestriction.sml
@@ -14,10 +14,10 @@ structure ExpPatRestriction =
 struct
 
   datatype t =
-    At    (* AtExp/Pat *)
-  | App   (* AppExp/Pat *)
-  | Inf   (* InfExp/Pat *)
-  | None  (* Exp *)
+    At (* AtExp/Pat *)
+  | App (* AppExp/Pat *)
+  | Inf (* InfExp/Pat *)
+  | None (* Exp *)
 
   fun appOkay restrict =
     case restrict of

--- a/src/parse/FixExpPrecedence.sml
+++ b/src/parse/FixExpPrecedence.sml
@@ -55,16 +55,10 @@ struct
     * `maybeRotateLeft`!
     *)
 
-  type replacer =
-    { exp: Ast.Exp.exp
-    , replaceWith: Ast.Exp.exp -> Ast.Exp.exp
-    }
+  type replacer = {exp: Ast.Exp.exp, replaceWith: Ast.Exp.exp -> Ast.Exp.exp}
 
   datatype info =
-    F of { prec: int
-         , left: replacer option
-         , right: replacer option
-         }
+    F of {prec: int, left: replacer option, right: replacer option}
 
 
   fun getInfo e =
@@ -74,7 +68,8 @@ struct
       case e of
         Typed {exp, colon, ty} =>
           let
-            fun leftReplaceWith e = Typed {exp=e, colon=colon, ty=ty}
+            fun leftReplaceWith e =
+              Typed {exp = e, colon = colon, ty = ty}
           in
             F { prec = 10
               , left = SOME {exp = exp, replaceWith = leftReplaceWith}
@@ -85,9 +80,9 @@ struct
       | Andalso {left, andalsoo, right} =>
           let
             fun leftReplaceWith e =
-              Andalso {left=e, andalsoo=andalsoo, right=right}
+              Andalso {left = e, andalsoo = andalsoo, right = right}
             fun rightReplaceWith e =
-              Andalso {left=left, andalsoo=andalsoo, right=e}
+              Andalso {left = left, andalsoo = andalsoo, right = e}
           in
             F { prec = 9
               , left = SOME {exp = left, replaceWith = leftReplaceWith}
@@ -98,9 +93,9 @@ struct
       | Orelse {left, orelsee, right} =>
           let
             fun leftReplaceWith e =
-              Orelse {left=e, orelsee=orelsee, right=right}
+              Orelse {left = e, orelsee = orelsee, right = right}
             fun rightReplaceWith e =
-              Orelse {left=left, orelsee=orelsee, right=e}
+              Orelse {left = left, orelsee = orelsee, right = e}
           in
             F { prec = 8
               , left = SOME {exp = left, replaceWith = leftReplaceWith}
@@ -111,7 +106,8 @@ struct
       | Handle {exp, handlee, elems, delims} =>
           let
             fun leftReplaceWith e =
-              Handle {exp = e, handlee=handlee, elems=elems, delims=delims}
+              Handle
+                {exp = e, handlee = handlee, elems = elems, delims = delims}
           in
             F { prec = 7
               , left = SOME {exp = exp, replaceWith = leftReplaceWith}
@@ -122,7 +118,7 @@ struct
       | Raise {raisee, exp} =>
           let
             fun replaceRightWith e =
-              Raise {raisee=raisee, exp=e}
+              Raise {raisee = raisee, exp = e}
           in
             F { prec = 6
               , left = NONE
@@ -134,7 +130,13 @@ struct
           let
             fun replaceRightWith e =
               IfThenElse
-              {iff=iff, exp1=exp1, thenn=thenn, exp2=exp2, elsee=elsee, exp3=e}
+                { iff = iff
+                , exp1 = exp1
+                , thenn = thenn
+                , exp2 = exp2
+                , elsee = elsee
+                , exp3 = e
+                }
           in
             F { prec = 5
               , left = NONE
@@ -145,7 +147,7 @@ struct
       | While {whilee, exp1, doo, exp2} =>
           let
             fun replaceRightWith e =
-              While {whilee=whilee, exp1=exp1, doo=doo, exp2=e}
+              While {whilee = whilee, exp1 = exp1, doo = doo, exp2 = e}
           in
             F { prec = 4
               , left = NONE
@@ -153,27 +155,23 @@ struct
               }
           end
 
-      | _ =>
-          F { prec = 0
-            , left = NONE
-            , right = NONE
-            }
+      | _ => F {prec = 0, left = NONE, right = NONE}
     end
 
 
   fun maybeRotateLeft e =
     let
-      val F {prec=rootPrecedence, right, ...} = getInfo e
+      val F {prec = rootPrecedence, right, ...} = getInfo e
     in
       case right of
         NONE => e
-      | SOME {exp=rootRight, replaceWith=rootReplaceRightWith} =>
+      | SOME {exp = rootRight, replaceWith = rootReplaceRightWith} =>
           let
-            val F {prec=rightPrecedence, left, ...} = getInfo rootRight
+            val F {prec = rightPrecedence, left, ...} = getInfo rootRight
           in
             case left of
               NONE => e
-            | SOME {exp=rightLeft, replaceWith=rightReplaceLeftWith} =>
+            | SOME {exp = rightLeft, replaceWith = rightReplaceLeftWith} =>
                 if rootPrecedence > rightPrecedence then
                   rightReplaceLeftWith (rootReplaceRightWith rightLeft)
                 else

--- a/src/parse/InfixDict.sml
+++ b/src/parse/InfixDict.sml
@@ -34,10 +34,7 @@ end =
 struct
   structure D =
     Dict
-      (struct
-        type t = string
-        val compare: t * t -> order = String.compare
-      end)
+      (struct type t = string val compare: t * t -> order = String.compare end)
 
   open D
 
@@ -46,19 +43,32 @@ struct
 
   type t = fixity D.t list
 
-  fun L (str, p) = (str, Infix (p, AssocLeft))
-  fun R (str, p) = (str, Infix (p, AssocRight))
+  fun L (str, p) =
+    (str, Infix (p, AssocLeft))
+  fun R (str, p) =
+    (str, Infix (p, AssocRight))
 
   val initialTopLevel: t =
-    [ fromList
-        [ L("div", 7), L("mod", 7), L("*", 7), L("/", 7)
-        , L("+", 6), L("-", 6), L("^", 6)
-        , R("::", 5), R("@", 5)
-        , L("=", 4), L("<", 4), L(">", 4), L("<=", 4), L(">=", 4), L("<>", 4)
-        , L(":=", 3), L("o", 3)
-        , L("before", 0)
-        ]
-    ]
+    [fromList
+       [ L ("div", 7)
+       , L ("mod", 7)
+       , L ("*", 7)
+       , L ("/", 7)
+       , L ("+", 6)
+       , L ("-", 6)
+       , L ("^", 6)
+       , R ("::", 5)
+       , R ("@", 5)
+       , L ("=", 4)
+       , L ("<", 4)
+       , L (">", 4)
+       , L ("<=", 4)
+       , L (">=", 4)
+       , L ("<>", 4)
+       , L (":=", 3)
+       , L ("o", 3)
+       , L ("before", 0)
+       ]]
 
   exception TopScope
 
@@ -67,7 +77,8 @@ struct
   fun newScope d = D.empty :: d
 
   fun popScope [_] = raise TopScope
-    | popScope (x :: d) = {old=d, popped=[x]}
+    | popScope (x :: d) =
+        {old = d, popped = [x]}
     | popScope [] = raise Fail "Impossible! Bug in InfixDict"
 
   fun find d tok =
@@ -90,15 +101,12 @@ struct
     | _ => false
 
   fun setInfix d (tok, prec, assoc) =
-    D.insert (List.hd d) (Token.toString tok, Infix (prec, assoc))
-    :: List.tl d
+    D.insert (List.hd d) (Token.toString tok, Infix (prec, assoc)) :: List.tl d
 
   fun setNonfix d tok =
-    D.insert (List.hd d) (Token.toString tok, Nonfix)
-    :: List.tl d
+    D.insert (List.hd d) (Token.toString tok, Nonfix) :: List.tl d
 
-  fun merge (d1, d2) =
-    d2 @ d1
+  fun merge (d1, d2) = d2 @ d1
 
   fun lookupPrecedence (d: t) tok =
     case find d tok of

--- a/src/parse/ParseFunNameArgs.sml
+++ b/src/parse/ParseFunNameArgs.sml
@@ -8,9 +8,7 @@ sig
   type ('a, 'b) parser = ('a, 'b) ParserCombinators.parser
   type tokens = Token.t Seq.t
 
-  val fname_args: tokens
-               -> InfixDict.t
-               -> (int, Ast.Exp.fname_args) parser
+  val fname_args: tokens -> InfixDict.t -> (int, Ast.Exp.fname_args) parser
 end =
 struct
 
@@ -29,7 +27,8 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
+      fun check f i =
+        i < numToks andalso f (tok i)
       fun isReserved rc i =
         check (fn t => Token.Reserved rc = Token.getClass t) i
 
@@ -42,8 +41,7 @@ struct
           fun continue i =
             not (isReserved Token.Colon i orelse isReserved Token.Equal i)
         in
-          PC.zeroOrMoreWhile
-            continue (PP.pat toks infdict Restriction.At) i
+          PC.zeroOrMoreWhile continue (PP.pat toks infdict Restriction.At) i
         end
 
 
@@ -70,13 +68,7 @@ struct
           (* val _ = print ("prefixedFun\n") *)
           val (i, args) = restOfCurriedArgs i
         in
-          ( i
-          , Ast.Exp.PrefixedFun
-              { opp = opp
-              , id = id
-              , args = args
-              }
-          )
+          (i, Ast.Exp.PrefixedFun {opp = opp, id = id, args = args})
         end
 
 
@@ -85,13 +77,7 @@ struct
           (* val _ = print ("infixedFun\n") *)
           val (i, rarg) = PP.pat toks infdict Restriction.At i
         in
-          ( i
-          , Ast.Exp.InfixedFun
-              { larg = larg
-              , id = id
-              , rarg = rarg
-              }
-          )
+          (i, Ast.Exp.InfixedFun {larg = larg, id = id, rarg = rarg})
         end
 
 
@@ -105,12 +91,11 @@ struct
           }
     in
       if isInfixedValueIdentifierNoEqual i then
-        infixedFun firstPat (tok i) (i+1)
+        infixedFun firstPat (tok i) (i + 1)
       else
         case firstPat of
           Ast.Pat.Parens
-            {left=lp, right=rp, pat = Ast.Pat.Infix {left, id, right}}
-            =>
+            {left = lp, right = rp, pat = Ast.Pat.Infix {left, id, right}} =>
             curriedInfix lp left id right rp i
 
         | Ast.Pat.Ident {opp, id} =>

--- a/src/parse/ParseSigExpAndSpec.sml
+++ b/src/parse/ParseSigExpAndSpec.sml
@@ -34,31 +34,23 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
-      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i =
+        i < numToks andalso f (tok i)
+      fun isReserved rc =
+        check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun parse_reserved rc i =
         PS.reserved toks rc i
-      fun parse_tyvars i =
-        PS.tyvars toks i
-      fun parse_sigid i =
-        PS.sigid toks i
-      fun parse_strid i =
-        PS.strid toks i
-      fun parse_funid i =
-        PS.funid toks i
-      fun parse_vid i =
-        PS.vid toks i
-      fun parse_longvid i =
-        PS.longvid toks i
-      fun parse_tycon i =
-        PS.tycon toks i
-      fun parse_maybeLongTycon i =
-        PS.maybeLongTycon toks i
-      fun parse_maybeLongStrid i =
-        PS.maybeLongStrid toks i
-      fun parse_ty i =
-        PT.ty toks i
+      fun parse_tyvars i = PS.tyvars toks i
+      fun parse_sigid i = PS.sigid toks i
+      fun parse_strid i = PS.strid toks i
+      fun parse_funid i = PS.funid toks i
+      fun parse_vid i = PS.vid toks i
+      fun parse_longvid i = PS.longvid toks i
+      fun parse_tycon i = PS.tycon toks i
+      fun parse_maybeLongTycon i = PS.maybeLongTycon toks i
+      fun parse_maybeLongStrid i = PS.maybeLongStrid toks i
+      fun parse_ty i = PT.ty toks i
 
 
       fun parse_oneOrMoreDelimitedByReserved x i =
@@ -78,12 +70,11 @@ struct
         let
           fun nextIsWhereOrAndType i =
             (isReserved Token.Where i orelse isReserved Token.And i)
-            andalso
-            (isReserved Token.Type (i+1))
+            andalso (isReserved Token.Type (i + 1))
 
           fun parseOne i =
             let
-              val (i, wheree) = (i+1, tok i)
+              val (i, wheree) = (i + 1, tok i)
               val (i, typee) = parse_reserved Token.Type i
               val (i, tyvars) = parse_tyvars i
               val (i, tycon) = parse_maybeLongTycon i
@@ -101,15 +92,9 @@ struct
               )
             end
 
-          val (i, elems) =
-            parse_oneOrMoreWhile nextIsWhereOrAndType parseOne i
+          val (i, elems) = parse_oneOrMoreWhile nextIsWhereOrAndType parseOne i
         in
-          ( i
-          , Ast.Sig.WhereType
-              { sigexp = sigexp
-              , elems = elems
-              }
-          )
+          (i, Ast.Sig.WhereType {sigexp = sigexp, elems = elems})
         end
 
 
@@ -118,17 +103,11 @@ struct
         *)
       and consume_sigExpSigEnd i =
         let
-          val sigg = tok (i-1)
+          val sigg = tok (i - 1)
           val (i, spec) = parse_spec toks infdict i
           val (i, endd) = parse_reserved Token.End i
         in
-          ( i
-          , Ast.Sig.Spec
-              { sigg = sigg
-              , spec = spec
-              , endd = endd
-              }
-          )
+          (i, Ast.Sig.Spec {sigg = sigg, spec = spec, endd = endd})
         end
 
 
@@ -136,18 +115,14 @@ struct
         let
           val (i, sigexp) =
             if isReserved Token.Sig i then
-              consume_sigExpSigEnd (i+1)
+              consume_sigExpSigEnd (i + 1)
             else
-              let
-                val (i, sigid) = parse_sigid i
-              in
-                (i, Ast.Sig.Ident sigid)
+              let val (i, sigid) = parse_sigid i
+              in (i, Ast.Sig.Ident sigid)
               end
         in
-          if isReserved Token.Where i then
-            consume_sigExpWhereType sigexp i
-          else
-            (i, sigexp)
+          if isReserved Token.Where i then consume_sigExpWhereType sigexp i
+          else (i, sigexp)
         end
 
     in
@@ -164,25 +139,20 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
-      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i =
+        i < numToks andalso f (tok i)
+      fun isReserved rc =
+        check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun parse_reserved rc i =
         PS.reserved toks rc i
-      fun parse_tyvars i =
-        PS.tyvars toks i
-      fun parse_vid i =
-        PS.vid toks i
-      fun parse_longvid i =
-        PS.longvid toks i
-      fun parse_tycon i =
-        PS.tycon toks i
-      fun parse_maybeLongTycon i =
-        PS.maybeLongTycon toks i
-      fun parse_maybeLongStrid i =
-        PS.maybeLongStrid toks i
-      fun parse_ty i =
-        PT.ty toks i
+      fun parse_tyvars i = PS.tyvars toks i
+      fun parse_vid i = PS.vid toks i
+      fun parse_longvid i = PS.longvid toks i
+      fun parse_tycon i = PS.tycon toks i
+      fun parse_maybeLongTycon i = PS.maybeLongTycon toks i
+      fun parse_maybeLongStrid i = PS.maybeLongStrid toks i
+      fun parse_ty i = PT.ty toks i
 
 
       fun parse_oneOrMoreDelimitedByReserved x i =
@@ -206,16 +176,12 @@ struct
                 else
                   let
                     val off = tok i
-                    val (i, ty) = parse_ty (i+1)
+                    val (i, ty) = parse_ty (i + 1)
                   in
                     (i, SOME {off = off, ty = ty})
                   end
             in
-              ( i
-              , { vid = vid
-                , arg = arg
-                }
-              )
+              (i, {vid = vid, arg = arg})
             end
 
           fun parseElem i =
@@ -226,8 +192,7 @@ struct
 
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved
-                  {parseElem = parse_condesc, delim = Token.Bar}
-                  i
+                  {parseElem = parse_condesc, delim = Token.Bar} i
             in
               ( i
               , { tyvars = tyvars
@@ -241,14 +206,9 @@ struct
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseElem, delim = Token.And}
-              i
+              {parseElem = parseElem, delim = Token.And} i
         in
-          ( i
-          , { elems = elems
-            , delims = delims
-            }
-          )
+          (i, {elems = elems, delims = delims})
         end
 
       (** val vid : ty [and ...]
@@ -256,7 +216,7 @@ struct
         *)
       fun consume_sigSpecVal i =
         let
-          val vall = tok (i-1)
+          val vall = tok (i - 1)
 
           fun parseOne i =
             let
@@ -264,26 +224,14 @@ struct
               val (i, colon) = parse_reserved Token.Colon i
               val (i, ty) = parse_ty i
             in
-              ( i
-              , { vid = vid
-                , colon = colon
-                , ty = ty
-                }
-              )
+              (i, {vid = vid, colon = colon, ty = ty})
             end
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
-          ( i
-          , Ast.Sig.Val
-              { vall = vall
-              , elems = elems
-              , delims = delims
-              }
-          )
+          (i, Ast.Sig.Val {vall = vall, elems = elems, delims = delims})
         end
 
 
@@ -301,7 +249,7 @@ struct
           )
         else
           let
-            val (i, firstDelim) = (i+1, tok i)
+            val (i, firstDelim) = (i + 1, tok i)
 
             fun parseOne i =
               let
@@ -310,19 +258,12 @@ struct
                 val (i, eq) = parse_reserved Token.Equal i
                 val (i, ty) = parse_ty i
               in
-                ( i
-                , { tyvars = tyvars
-                  , tycon = tycon
-                  , eq = eq
-                  , ty = ty
-                  }
-                )
+                (i, {tyvars = tyvars, tycon = tycon, eq = eq, ty = ty})
               end
 
             val (i, {elems, delims}) =
               parse_oneOrMoreDelimitedByReserved
-                {parseElem = parseOne, delim = Token.And}
-                i
+                {parseElem = parseOne, delim = Token.And} i
           in
             ( i
             , Ast.Sig.TypeAbbreviation
@@ -348,24 +289,19 @@ struct
           )
         else
           let
-            val (i, firstDelim) = (i+1, tok i)
+            val (i, firstDelim) = (i + 1, tok i)
 
             fun parseOne i =
               let
                 val (i, tyvars) = parse_tyvars i
                 val (i, tycon) = parse_tycon i
               in
-                ( i
-                , { tyvars = tyvars
-                  , tycon = tycon
-                  }
-                )
+                (i, {tyvars = tyvars, tycon = tycon})
               end
 
             val (i, {elems, delims}) =
               parse_oneOrMoreDelimitedByReserved
-                {parseElem = parseOne, delim = Token.And}
-                i
+                {parseElem = parseOne, delim = Token.And} i
           in
             ( i
             , Ast.Sig.Type
@@ -387,12 +323,11 @@ struct
               val (i, eq) = parse_reserved Token.Equal i
               val (i, ty) = parse_ty i
             in
-              consume_sigSpecTypeAbbreviation
-                typee {tyvars=tyvars, tycon=tycon, eq=eq, ty=ty} i
+              consume_sigSpecTypeAbbreviation typee
+                {tyvars = tyvars, tycon = tycon, eq = eq, ty = ty} i
             end
           else
-            consume_sigSpecType
-              typee {tyvars=tyvars, tycon=tycon} i
+            consume_sigSpecType typee {tyvars = tyvars, tycon = tycon} i
         end
 
 
@@ -401,31 +336,22 @@ struct
         *)
       fun consume_sigSpecEqtype i =
         let
-          val eqtypee = tok (i-1)
+          val eqtypee = tok (i - 1)
 
           fun parseOne i =
             let
               val (i, tyvars) = parse_tyvars i
               val (i, tycon) = parse_tycon i
             in
-              ( i
-              , { tyvars =  tyvars
-                , tycon = tycon
-                }
-              )
+              (i, {tyvars = tyvars, tycon = tycon})
             end
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
           ( i
-          , Ast.Sig.Eqtype
-              { eqtypee = eqtypee
-              , elems = elems
-              , delims = delims
-              }
+          , Ast.Sig.Eqtype {eqtypee = eqtypee, elems = elems, delims = delims}
           )
         end
 
@@ -437,30 +363,27 @@ struct
         *         ^
         *)
       fun consume_sigSpecDatatypeDeclarationOrReplication i =
-        if (
-          isReserved Token.OpenParen i (* datatype ('a, ...) foo *)
-          orelse check Token.isTyVar i (* datatype 'a foo *)
-          orelse ( (* datatype foo = A *)
-            check Token.isValueIdentifierNoEqual i
-            andalso isReserved Token.Equal (i+1)
-            andalso not (isReserved Token.Datatype (i+2))
-          )
-        ) then
+        if
+          (isReserved Token.OpenParen i (* datatype ('a, ...) foo *)
+           orelse check Token.isTyVar i (* datatype 'a foo *)
+           orelse
+           ( (* datatype foo = A *)
+             check Token.isValueIdentifierNoEqual i
+             andalso isReserved Token.Equal (i + 1)
+             andalso not (isReserved Token.Datatype (i + 2))))
+        then
           let
-            val datatypee = tok (i-1)
+            val datatypee = tok (i - 1)
             val (i, {elems, delims}) = parse_datdesc i
           in
             ( i
             , Ast.Sig.Datatype
-              { datatypee = datatypee
-              , elems = elems
-              , delims = delims
-              }
+                {datatypee = datatypee, elems = elems, delims = delims}
             )
           end
         else
           let
-            val left_datatypee = tok (i-1)
+            val left_datatypee = tok (i - 1)
             val (i, left_id) = parse_vid i
             val (i, eq) = parse_reserved Token.Equal i
             val (i, right_datatypee) = parse_reserved Token.Datatype i
@@ -468,12 +391,12 @@ struct
           in
             ( i
             , Ast.Sig.ReplicateDatatype
-              { left_datatypee = left_datatypee
-              , left_id = left_id
-              , eq = eq
-              , right_datatypee = right_datatypee
-              , right_id = right_id
-              }
+                { left_datatypee = left_datatypee
+                , left_id = left_id
+                , eq = eq
+                , right_datatypee = right_datatypee
+                , right_id = right_id
+                }
             )
           end
 
@@ -483,7 +406,7 @@ struct
         *)
       fun consume_sigSpecException i =
         let
-          val exceptionn = tok (i-1)
+          val exceptionn = tok (i - 1)
           fun parseOne i =
             let
               val (i, vid) = parse_vid i
@@ -493,29 +416,21 @@ struct
                 else
                   let
                     val off = tok i
-                    val (i, ty) = parse_ty (i+1)
+                    val (i, ty) = parse_ty (i + 1)
                   in
                     (i, SOME {off = off, ty = ty})
                   end
             in
-              ( i
-              , { vid = vid
-                , arg = arg
-                }
-              )
+              (i, {vid = vid, arg = arg})
             end
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
           ( i
           , Ast.Sig.Exception
-              { exceptionn = exceptionn
-              , elems = elems
-              , delims= delims
-              }
+              {exceptionn = exceptionn, elems = elems, delims = delims}
           )
         end
 
@@ -527,16 +442,11 @@ struct
         let
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parse_maybeLongStrid, delim = Token.Equal}
-              i
+              {parseElem = parse_maybeLongStrid, delim = Token.Equal} i
         in
           ( i
           , Ast.Sig.Sharing
-              { spec = spec
-              , sharingg = sharingg
-              , elems = elems
-              , delims = delims
-              }
+              {spec = spec, sharingg = sharingg, elems = elems, delims = delims}
           )
         end
 
@@ -548,8 +458,7 @@ struct
         let
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parse_maybeLongTycon, delim = Token.Equal}
-              i
+              {parseElem = parse_maybeLongTycon, delim = Token.Equal} i
         in
           ( i
           , Ast.Sig.SharingType
@@ -567,18 +476,16 @@ struct
         let
           val (again, (i, spec)) =
             if isReserved Token.Sharing i then
-              if isReserved Token.Type (i+1) then
-                (true, consume_sigSharingType
-                         spec (tok i) (tok (i+1)) (i+2))
+              if isReserved Token.Type (i + 1) then
+                ( true
+                , consume_sigSharingType spec (tok i) (tok (i + 1)) (i + 2)
+                )
               else
-                (true, consume_sigSharing spec (tok i) (i+1))
+                (true, consume_sigSharing spec (tok i) (i + 1))
             else
               (false, (i, spec))
         in
-          if again then
-            consume_afterSigSpec spec i
-          else
-            (i, spec)
+          if again then consume_afterSigSpec spec i else (i, spec)
         end
 
 
@@ -587,7 +494,7 @@ struct
         *)
       fun consume_sigSpecStructure i =
         let
-          val structuree = tok (i-1)
+          val structuree = tok (i - 1)
 
           fun parseOne i =
             let
@@ -595,25 +502,16 @@ struct
               val (i, colon) = parse_reserved Token.Colon i
               val (i, sigexp) = parse_sigexp toks infdict i
             in
-              ( i
-              , { id = id
-                , colon = colon
-                , sigexp = sigexp
-                }
-              )
+              (i, {id = id, colon = colon, sigexp = sigexp})
             end
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
           ( i
           , Ast.Sig.Structure
-              { structuree = structuree
-              , elems = elems
-              , delims = delims
-              }
+              {structuree = structuree, elems = elems, delims = delims}
           )
         end
 
@@ -626,24 +524,17 @@ struct
         *)
       and consume_sigSpecInclude i =
         let
-          val includee = tok (i-1)
+          val includee = tok (i - 1)
           val (i, sigexp) = parse_sigexp toks infdict i
 
           fun makeInclude i =
-            ( i
-            , Ast.Sig.Include
-                { includee = includee
-                , sigexp = sigexp
-                }
-            )
+            (i, Ast.Sig.Include {includee = includee, sigexp = sigexp})
 
           fun makeIncludeIds firstId i =
             let
               val (i, ids) =
-                PC.zeroOrMoreWhile
-                (check Token.isStrIdentifier)
-                (fn i => (i+1, tok i))
-                i
+                PC.zeroOrMoreWhile (check Token.isStrIdentifier)
+                  (fn i => (i + 1, tok i)) i
             in
               ( i
               , Ast.Sig.IncludeIds
@@ -655,10 +546,8 @@ struct
 
         in
           case sigexp of
-            Ast.Sig.Ident id =>
-              makeIncludeIds id i
-          | _ =>
-              makeInclude i
+            Ast.Sig.Ident id => makeIncludeIds id i
+          | _ => makeInclude i
         end
 
 
@@ -666,19 +555,19 @@ struct
         let
           val (i, spec) =
             if isReserved Token.Val i then
-              consume_sigSpecVal (i+1)
+              consume_sigSpecVal (i + 1)
             else if isReserved Token.Type i then
-              consume_sigSpecTypeOrAbbreviation (tok i) (i+1)
+              consume_sigSpecTypeOrAbbreviation (tok i) (i + 1)
             else if isReserved Token.Eqtype i then
-              consume_sigSpecEqtype (i+1)
+              consume_sigSpecEqtype (i + 1)
             else if isReserved Token.Datatype i then
-              consume_sigSpecDatatypeDeclarationOrReplication (i+1)
+              consume_sigSpecDatatypeDeclarationOrReplication (i + 1)
             else if isReserved Token.Exception i then
-              consume_sigSpecException (i+1)
+              consume_sigSpecException (i + 1)
             else if isReserved Token.Structure i then
-              consume_sigSpecStructure (i+1)
+              consume_sigSpecStructure (i + 1)
             else if isReserved Token.Include i then
-              consume_sigSpecInclude (i+1)
+              consume_sigSpecInclude (i + 1)
             else
               ParserUtils.tokError toks
                 { pos = i
@@ -693,42 +582,25 @@ struct
       and consume_sigSpec i =
         let
           fun consume_maybeSemicolon i =
-            if isReserved Token.Semicolon i then
-              (i+1, SOME (tok i))
-            else
-              (i, NONE)
+            if isReserved Token.Semicolon i then (i + 1, SOME (tok i))
+            else (i, NONE)
 
           val (i, specs) =
-            parse_zeroOrMoreWhile
-              (fn i => check Token.isSigSpecStartToken i)
-              ( parse_two
-                ( consume_oneSigSpec
-                , consume_maybeSemicolon
-                )
-              )
-              i
+            parse_zeroOrMoreWhile (fn i => check Token.isSigSpecStartToken i)
+              (parse_two (consume_oneSigSpec, consume_maybeSemicolon)) i
 
           fun makeSpecMultiple () =
             Ast.Sig.Multiple
-              { elems = Seq.map #1 specs
-              , delims = Seq.map #2 specs
-              }
+              {elems = Seq.map #1 specs, delims = Seq.map #2 specs}
 
           val result =
             case Seq.length specs of
-              0 =>
-                Ast.Sig.EmptySpec
+              0 => Ast.Sig.EmptySpec
             | 1 =>
-                let
-                  val (spec, semicolon) = Seq.nth specs 0
-                in
-                  if isSome semicolon then
-                    makeSpecMultiple ()
-                  else
-                    spec
+                let val (spec, semicolon) = Seq.nth specs 0
+                in if isSome semicolon then makeSpecMultiple () else spec
                 end
-            | _ =>
-                makeSpecMultiple ()
+            | _ => makeSpecMultiple ()
         in
           (i, result)
         end
@@ -742,8 +614,10 @@ struct
     * ========================================================================
     *)
 
-  fun spec toks infdict i = parse_spec toks infdict i
-  fun sigexp toks infdict i = parse_sigexp toks infdict i
+  fun spec toks infdict i =
+    parse_spec toks infdict i
+  fun sigexp toks infdict i =
+    parse_sigexp toks infdict i
 
 
 end

--- a/src/parse/ParseSimple.sml
+++ b/src/parse/ParseSimple.sml
@@ -48,74 +48,74 @@ struct
 
   fun reserved toks rc i =
     if isReserved toks rc i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
         , what =
-            "Unexpected token. Expected to see "
-            ^ "'" ^ Token.reservedToString rc ^ "'"
+            "Unexpected token. Expected to see " ^ "'"
+            ^ Token.reservedToString rc ^ "'"
         , explain = NONE
         }
 
 
   fun maybeReserved toks rc i =
-    if isReserved toks rc i then
-      (i+1, SOME (Seq.nth toks i))
-    else
-      (i, NONE)
+    if isReserved toks rc i then (i + 1, SOME (Seq.nth toks i)) else (i, NONE)
 
 
   fun tyvar toks i =
     if check toks Token.isTyVar i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
-        { pos = i
-        , what = "Expected tyvar."
-        , explain = NONE
-        }
+        {pos = i, what = "Expected tyvar.", explain = NONE}
 
 
   fun strid toks i =
     if check toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected structure identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun sigid toks i =
     if check toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected signature identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun funid toks i =
     if check toks Token.isStrIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected functor identifier."
-        , explain = SOME "Must be alphanumeric, and cannot start with a\
-                         \ prime (')"
+        , explain =
+            SOME
+              "Must be alphanumeric, and cannot start with a\
+              \ prime (')"
         }
 
 
   fun vid toks i =
     if check toks Token.isValueIdentifier i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
@@ -126,7 +126,7 @@ struct
 
   fun longvid toks i =
     if check toks Token.isMaybeLongIdentifier i then
-      (i+1, MaybeLongToken.make (Seq.nth toks i))
+      (i + 1, MaybeLongToken.make (Seq.nth toks i))
     else
       ParserUtils.tokError toks
         { pos = i
@@ -136,18 +136,15 @@ struct
 
   fun recordLabel toks i =
     if check toks Token.isRecordLabel i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
-        { pos = i
-        , what = "Expected record label."
-        , explain = NONE
-        }
+        {pos = i, what = "Expected record label.", explain = NONE}
 
 
   fun tycon toks i =
     if check toks Token.isTyCon i then
-      (i+1, Seq.nth toks i)
+      (i + 1, Seq.nth toks i)
     else
       ParserUtils.tokError toks
         { pos = i
@@ -158,42 +155,47 @@ struct
 
   fun maybeLongTycon toks i =
     if check toks Token.isMaybeLongTyCon i then
-      (i+1, MaybeLongToken.make (Seq.nth toks i))
+      (i + 1, MaybeLongToken.make (Seq.nth toks i))
     else
       ParserUtils.tokError toks
         { pos = i
-        , what = "Unexpected token. Invalid (possibly qualified)\
-                 \ type constructor."
+        , what =
+            "Unexpected token. Invalid (possibly qualified)\
+            \ type constructor."
         , explain = NONE
         }
 
 
   fun maybeLongStrid toks i =
     if check toks Token.isMaybeLongStrIdentifier i then
-      (i+1, MaybeLongToken.make (Seq.nth toks i))
+      (i + 1, MaybeLongToken.make (Seq.nth toks i))
     else
       ParserUtils.tokError toks
         { pos = i
-        , what = "Unexpected token. Invalid (possibly qualified)\
-                 \ structure identifier."
+        , what =
+            "Unexpected token. Invalid (possibly qualified)\
+            \ structure identifier."
         , explain = NONE
         }
 
 
   fun tyvars toks i =
-    if check toks Token.isTyVar i then
-      (i+1, Ast.SyntaxSeq.One (Seq.nth toks i))
-    else if not (isReserved toks Token.OpenParen i
-                 andalso check toks Token.isTyVar (i+1)) then
+    if
+      check toks Token.isTyVar i
+    then
+      (i + 1, Ast.SyntaxSeq.One (Seq.nth toks i))
+    else if
+      not
+        (isReserved toks Token.OpenParen i
+         andalso check toks Token.isTyVar (i + 1))
+    then
       (i, Ast.SyntaxSeq.Empty)
     else
       let
-        val (i, openParen) = (i+1, Seq.nth toks i)
+        val (i, openParen) = (i + 1, Seq.nth toks i)
         val (i, {elems, delims}) =
-          ParserCombinators.oneOrMoreDelimitedByReserved
-            toks
-            {parseElem = tyvar toks, delim = Token.Comma}
-            i
+          ParserCombinators.oneOrMoreDelimitedByReserved toks
+            {parseElem = tyvar toks, delim = Token.Comma} i
         val (i, closeParen) = reserved toks Token.CloseParen i
       in
         ( i

--- a/src/parse/ParseTy.sml
+++ b/src/parse/ParseTy.sml
@@ -23,12 +23,12 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
+      fun check f i =
+        i < numToks andalso f (tok i)
       fun isReserved rc i =
         check (fn t => Token.Reserved rc = Token.getClass t) i
 
-      fun parse_recordLabel i =
-        PS.recordLabel toks i
+      fun parse_recordLabel i = PS.recordLabel toks i
       fun parse_reserved rc i =
         PS.reserved toks rc i
       fun parse_oneOrMoreDelimitedByReserved x i =
@@ -40,31 +40,26 @@ struct
         let
           val (i, ty) =
             if check Token.isTyVar i then
-              ( i+1
-              , Ast.Ty.Var (tok i)
-              )
+              (i + 1, Ast.Ty.Var (tok i))
             else if isReserved Token.OpenParen i then
               let
                 val leftParen = tok i
-                val (i, ty) = parse_tyWithRestriction {permitArrows=true, permitTuple=true} (i+1)
+                val (i, ty) =
+                  parse_tyWithRestriction
+                    {permitArrows = true, permitTuple = true} (i + 1)
               in
                 parse_tyParensOrSequence leftParen [ty] [] i
               end
             else if isReserved Token.OpenCurlyBracket i then
-              parse_tyRecord (tok i) (i+1)
+              parse_tyRecord (tok i) (i + 1)
             else if check Token.isMaybeLongIdentifier i then
-              ( i+1
+              ( i + 1
               , Ast.Ty.Con
-                  { id = MaybeLongToken.make (tok i)
-                  , args = Ast.SyntaxSeq.Empty
-                  }
+                  {id = MaybeLongToken.make (tok i), args = Ast.SyntaxSeq.Empty}
               )
             else
               ParserUtils.tokError toks
-                { pos = i
-                , what = "Parser bug!"
-                , explain = NONE
-                }
+                {pos = i, what = "Parser bug!", explain = NONE}
         in
           parse_afterTy restriction ty i
         end
@@ -78,12 +73,13 @@ struct
         *   ty longtycon    -- type constructor
         *   ty * ...        -- tuple
         *)
-      and parse_afterTy (restriction as {permitArrows: bool, permitTuple: bool}) ty i =
+      and parse_afterTy (restriction as {permitArrows: bool, permitTuple: bool})
+        ty i =
         let
           val (again, (i, ty)) =
             if check Token.isMaybeLongTyCon i then
               ( true
-              , ( i+1
+              , ( i + 1
                 , Ast.Ty.Con
                     { id = MaybeLongToken.make (tok i)
                     , args = Ast.SyntaxSeq.One ty
@@ -91,16 +87,13 @@ struct
                 )
               )
             else if permitArrows andalso isReserved Token.Arrow i then
-              (true, parse_tyArrow ty (i+1))
+              (true, parse_tyArrow ty (i + 1))
             else if permitTuple andalso check Token.isStar i then
-              (true, parse_tyTuple [ty] [] (i+1))
+              (true, parse_tyTuple [ty] [] (i + 1))
             else
               (false, (i, ty))
         in
-          if again then
-            parse_afterTy restriction ty i
-          else
-            (i, ty)
+          if again then parse_afterTy restriction ty i else (i, ty)
         end
 
 
@@ -113,14 +106,11 @@ struct
             let
               val (i, lab) = parse_recordLabel i
               val (i, colon) = parse_reserved Token.Colon i
-              val (i, ty) = parse_tyWithRestriction {permitArrows = true, permitTuple = true} i
+              val (i, ty) =
+                parse_tyWithRestriction
+                  {permitArrows = true, permitTuple = true} i
             in
-              ( i
-              , { lab = lab
-                , colon = colon
-                , ty = ty
-                }
-              )
+              (i, {lab = lab, colon = colon, ty = ty})
             end
 
           val (i, {elems, delims}) =
@@ -128,8 +118,7 @@ struct
               { parseElem = parseElem
               , delim = Token.Comma
               , shouldStop = isReserved Token.CloseCurlyBracket
-              }
-              i
+              } i
 
           val (i, rightBracket) = parse_reserved Token.CloseCurlyBracket i
         in
@@ -149,16 +138,11 @@ struct
         *)
       and parse_tyArrow fromTy i =
         let
-          val arrow = tok (i-1)
-          val (i, toTy) = parse_tyWithRestriction {permitArrows=true,permitTuple=true} i
+          val arrow = tok (i - 1)
+          val (i, toTy) =
+            parse_tyWithRestriction {permitArrows = true, permitTuple = true} i
         in
-          ( i
-          , Ast.Ty.Arrow
-              { from = fromTy
-              , arrow = arrow
-              , to = toTy
-              }
-          )
+          (i, Ast.Ty.Arrow {from = fromTy, arrow = arrow, to = toTy})
         end
 
 
@@ -167,19 +151,19 @@ struct
         *)
       and parse_tyTuple tys delims i =
         let
-          val star = tok (i-1)
-          val (i, ty) = parse_tyWithRestriction {permitArrows=false, permitTuple=false} i
+          val star = tok (i - 1)
+          val (i, ty) =
+            parse_tyWithRestriction {permitArrows = false, permitTuple = false}
+              i
           val tys = ty :: tys
           val delims = star :: delims
         in
           if check Token.isStar i then
-            parse_tyTuple tys delims (i+1)
+            parse_tyTuple tys delims (i + 1)
           else
             ( i
             , Ast.Ty.Tuple
-                { elems = Seq.fromRevList tys
-                , delims = Seq.fromRevList delims
-                }
+                {elems = Seq.fromRevList tys, delims = Seq.fromRevList delims}
             )
         end
 
@@ -192,22 +176,19 @@ struct
         *)
       and parse_tyParensOrSequence leftParen tys delims i =
         if isReserved Token.CloseParen i then
-          parse_tyEndParensOrSequence leftParen tys delims (i+1)
+          parse_tyEndParensOrSequence leftParen tys delims (i + 1)
         else if isReserved Token.Comma i then
           let
             val comma = tok i
             val (i, ty) =
-              parse_tyWithRestriction {permitArrows=true, permitTuple=true} (i+1)
+              parse_tyWithRestriction {permitArrows = true, permitTuple = true}
+                (i + 1)
           in
             parse_tyParensOrSequence leftParen (ty :: tys) (comma :: delims) i
           end
         else
           ParserUtils.tokError toks
-            { pos = i
-            , what = "Unexpected token."
-            , explain = NONE
-            }
-
+            {pos = i, what = "Unexpected token.", explain = NONE}
 
 
       (** ( ty )
@@ -218,30 +199,23 @@ struct
         *)
       and parse_tyEndParensOrSequence leftParen tys delims i =
         let
-          val rightParen = tok (i-1)
+          val rightParen = tok (i - 1)
         in
           case (tys, delims) of
             ([ty], []) =>
-              ( i
-              , Ast.Ty.Parens
-                  { left = leftParen
-                  , ty = ty
-                  , right = rightParen
-                  }
-              )
+              (i, Ast.Ty.Parens {left = leftParen, ty = ty, right = rightParen})
 
           | _ =>
               if check Token.isMaybeLongTyCon i then
-                ( i+1
+                ( i + 1
                 , Ast.Ty.Con
                     { id = MaybeLongToken.make (tok i)
-                    , args =
-                        Ast.SyntaxSeq.Many
-                          { left = leftParen
-                          , elems = Seq.fromRevList tys
-                          , delims = Seq.fromRevList delims
-                          , right = rightParen
-                          }
+                    , args = Ast.SyntaxSeq.Many
+                        { left = leftParen
+                        , elems = Seq.fromRevList tys
+                        , delims = Seq.fromRevList delims
+                        , right = rightParen
+                        }
                     }
                 )
               else
@@ -253,9 +227,8 @@ struct
         end
 
     in
-      parse_tyWithRestriction {permitArrows=true, permitTuple=true} start
+      parse_tyWithRestriction {permitArrows = true, permitTuple = true} start
     end
-
 
 
 end

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -13,7 +13,10 @@ sig
   | JustComments of Token.t Seq.t
 
   val parse: {allowTopExp: bool} -> Source.t -> parser_output
-  val parseWithInfdict: {allowTopExp: bool} -> InfixDict.t -> Source.t -> (InfixDict.t * parser_output)
+  val parseWithInfdict: {allowTopExp: bool}
+                        -> InfixDict.t
+                        -> Source.t
+                        -> (InfixDict.t * parser_output)
 end =
 struct
 
@@ -22,9 +25,7 @@ struct
   structure PT = ParseTy
   structure PP = ParsePat
 
-  datatype parser_output =
-    Ast of Ast.t
-  | JustComments of Token.t Seq.t
+  datatype parser_output = Ast of Ast.t | JustComments of Token.t Seq.t
 
   structure Restriction = ExpPatRestriction
 
@@ -52,33 +53,26 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i = i < numToks andalso f (tok i)
-      fun is c = check (fn t => c = Token.getClass t)
-      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i =
+        i < numToks andalso f (tok i)
+      fun is c =
+        check (fn t => c = Token.getClass t)
+      fun isReserved rc =
+        check (fn t => Token.Reserved rc = Token.getClass t)
 
 
       fun parse_reserved rc i =
         PS.reserved toks rc i
-      fun parse_tyvars i =
-        PS.tyvars toks i
-      fun parse_sigid i =
-        PS.sigid toks i
-      fun parse_strid i =
-        PS.strid toks i
-      fun parse_funid i =
-        PS.funid toks i
-      fun parse_vid i =
-        PS.vid toks i
-      fun parse_longvid i =
-        PS.longvid toks i
-      fun parse_tycon i =
-        PS.tycon toks i
-      fun parse_maybeLongTycon i =
-        PS.maybeLongTycon toks i
-      fun parse_maybeLongStrid i =
-        PS.maybeLongStrid toks i
-      fun parse_ty i =
-        PT.ty toks i
+      fun parse_tyvars i = PS.tyvars toks i
+      fun parse_sigid i = PS.sigid toks i
+      fun parse_strid i = PS.strid toks i
+      fun parse_funid i = PS.funid toks i
+      fun parse_vid i = PS.vid toks i
+      fun parse_longvid i = PS.longvid toks i
+      fun parse_tycon i = PS.tycon toks i
+      fun parse_maybeLongTycon i = PS.maybeLongTycon toks i
+      fun parse_maybeLongStrid i = PS.maybeLongStrid toks i
+      fun parse_ty i = PT.ty toks i
 
 
       fun parse_oneOrMoreDelimitedByReserved x i =
@@ -101,7 +95,7 @@ struct
         *)
       fun consume_sigDec (i, infdict) : ((int * InfixDict.t) * Ast.topdec) =
         let
-          val signaturee = tok (i-1)
+          val signaturee = tok (i - 1)
 
           fun parseOne i =
             let
@@ -109,25 +103,15 @@ struct
               val (i, eq) = parse_reserved Token.Equal i
               val (i, sigexp) = consume_sigExp infdict i
             in
-              ( i
-              , { ident = sigid
-                , eq = eq
-                , sigexp = sigexp
-                }
-              )
+              (i, {ident = sigid, eq = eq, sigexp = sigexp})
             end
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
 
-          val result: Ast.topdec =
-            Ast.SigDec (Ast.Sig.Signature
-              { signaturee = signaturee
-              , elems = elems
-              , delims = delims
-              })
+          val result: Ast.topdec = Ast.SigDec (Ast.Sig.Signature
+            {signaturee = signaturee, elems = elems, delims = delims})
         in
           ((i, infdict), result)
         end
@@ -154,11 +138,7 @@ struct
           val (i, sigexp) = consume_sigExp infdict i
         in
           ( i
-          , Ast.Str.Constraint
-              { strexp = strexp
-              , colon = colon
-              , sigexp = sigexp
-              }
+          , Ast.Str.Constraint {strexp = strexp, colon = colon, sigexp = sigexp}
           )
         end
 
@@ -168,13 +148,7 @@ struct
           val ((i, _), strdec) = consume_strdec (i, infdict)
           val (i, endd) = parse_reserved Token.End i
         in
-          ( i
-          , Ast.Str.Struct
-              { structt = structt
-              , strdec = strdec
-              , endd = endd
-              }
-          )
+          (i, Ast.Str.Struct {structt = structt, strdec = strdec, endd = endd})
         end
 
 
@@ -187,9 +161,8 @@ struct
         *)
       and consume_strexpFunApp infdict funid lparen i =
         if
-          check Token.isDecStartToken i orelse
-          check Token.isStrDecStartToken i orelse
-          isReserved Token.CloseParen i
+          check Token.isDecStartToken i orelse check Token.isStrDecStartToken i
+          orelse isReserved Token.CloseParen i
         then
           let
             val ((i, _), strdec) = consume_strdec (i, infdict)
@@ -245,20 +218,26 @@ struct
       and consume_strexp infdict i =
         let
           val (i, strexp) =
-            if isReserved Token.Struct i then
-              consume_strexpStruct infdict (tok i) (i+1)
+            if
+              isReserved Token.Struct i
+            then
+              consume_strexpStruct infdict (tok i) (i + 1)
 
             else if
-              check Token.isStrIdentifier i andalso
-              isReserved Token.OpenParen (i+1)
+              check Token.isStrIdentifier i
+              andalso isReserved Token.OpenParen (i + 1)
             then
-              consume_strexpFunApp infdict (tok i) (tok (i+1)) (i+2)
+              consume_strexpFunApp infdict (tok i) (tok (i + 1)) (i + 2)
 
-            else if check Token.isMaybeLongStrIdentifier i then
-              (i+1, Ast.Str.Ident (MaybeLongToken.make (tok i)))
+            else if
+              check Token.isMaybeLongStrIdentifier i
+            then
+              (i + 1, Ast.Str.Ident (MaybeLongToken.make (tok i)))
 
-            else if isReserved Token.Let i then
-              consume_strexpLetInEnd infdict (tok i) (i+1)
+            else if
+              isReserved Token.Let i
+            then
+              consume_strexpLetInEnd infdict (tok i) (i + 1)
 
             else
               ParserUtils.tokError toks
@@ -274,16 +253,12 @@ struct
       and consume_afterStrexp infdict strexp i =
         let
           val (again, (i, strexp)) =
-            if isReserved Token.Colon i orelse isReserved Token.ColonArrow i
-            then
-              (true, consume_strexpConstraint infdict strexp (tok i) (i+1))
+            if isReserved Token.Colon i orelse isReserved Token.ColonArrow i then
+              (true, consume_strexpConstraint infdict strexp (tok i) (i + 1))
             else
               (false, (i, strexp))
         in
-          if again then
-            consume_afterStrexp infdict strexp i
-          else
-            (i, strexp)
+          if again then consume_afterStrexp infdict strexp i else (i, strexp)
         end
 
 
@@ -298,7 +273,7 @@ struct
           fun parse_maybeConstraint infdict i =
             if isReserved Token.Colon i orelse isReserved Token.ColonArrow i then
               let
-                val (i, colon) = (i+1, tok i)
+                val (i, colon) = (i + 1, tok i)
                 val (i, sigexp) = consume_sigExp infdict i
               in
                 (i, SOME {colon = colon, sigexp = sigexp})
@@ -324,15 +299,11 @@ struct
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
           ( i
           , Ast.Str.DecStructure
-              { structuree = structuree
-              , elems = elems
-              , delims = delims
-              }
+              {structuree = structuree, elems = elems, delims = delims}
           )
         end
 
@@ -349,7 +320,7 @@ struct
           val ((i, _), strdec2) = consume_strdec (i, infdict)
           val (i, endd) = parse_reserved Token.End i
         in
-          ( (i, original_infdict)   (** TODO: check this? *)
+          ( (i, original_infdict) (** TODO: check this? *)
           , Ast.Str.DecLocalInEnd
               { locall = locall
               , strdec1 = strdec1
@@ -361,24 +332,20 @@ struct
         end
 
 
-      and consume_exactlyOneStrdec (i, infdict)
-          : ((int * InfixDict.t) * Ast.Str.strdec) =
+      and consume_exactlyOneStrdec (i, infdict) :
+        ((int * InfixDict.t) * Ast.Str.strdec) =
         if isReserved Token.Structure i then
-          let
-            val (i, dec) = consume_strdecStructure infdict (tok i) (i+1)
-          in
-            ((i, infdict), dec)
+          let val (i, dec) = consume_strdecStructure infdict (tok i) (i + 1)
+          in ((i, infdict), dec)
           end
         else if isReserved Token.Local i then
-          consume_strdecLocalInEnd (tok i) (i+1, infdict)
+          consume_strdecLocalInEnd (tok i) (i + 1, infdict)
         else
           let
             val ((i, infdict), dec) =
-              ParseExpAndDec.dec {forceExactlyOne=true} toks (i, infdict)
+              ParseExpAndDec.dec {forceExactlyOne = true} toks (i, infdict)
           in
-            ( (i, infdict)
-            , Ast.Str.DecCore dec
-            )
+            ((i, infdict), Ast.Str.DecCore dec)
           end
 
 
@@ -386,13 +353,13 @@ struct
         let
           fun consume_maybeSemicolon (i, infdict) =
             if isReserved Token.Semicolon i then
-              ((i+1, infdict), SOME (tok i))
+              ((i + 1, infdict), SOME (tok i))
             else
               ((i, infdict), NONE)
 
           fun continue (i, _) =
-            check Token.isDecStartToken i orelse
-            check Token.isStrDecStartToken i
+            check Token.isDecStartToken i
+            orelse check Token.isStrDecStartToken i
 
           (** While we see a strdec start-token, parse pairs of
             *   (dec, semicolon option)
@@ -400,32 +367,22 @@ struct
             * declarations can affect local infixity.
             *)
           val ((i, infdict), strdecs) =
-            parse_zeroOrMoreWhile
-              continue
+            parse_zeroOrMoreWhile continue
               (parse_two (consume_exactlyOneStrdec, consume_maybeSemicolon))
               (i, infdict)
 
           fun makeDecMultiple () =
             Ast.Str.DecMultiple
-              { elems = Seq.map #1 strdecs
-              , delims = Seq.map #2 strdecs
-              }
+              {elems = Seq.map #1 strdecs, delims = Seq.map #2 strdecs}
 
           val result =
             case Seq.length strdecs of
-              0 =>
-                Ast.Str.DecEmpty
+              0 => Ast.Str.DecEmpty
             | 1 =>
-                let
-                  val (dec, semicolon) = Seq.nth strdecs 0
-                in
-                  if isSome semicolon then
-                    makeDecMultiple ()
-                  else
-                    dec
+                let val (dec, semicolon) = Seq.nth strdecs 0
+                in if isSome semicolon then makeDecMultiple () else dec
                 end
-            | _ =>
-                makeDecMultiple ()
+            | _ => makeDecMultiple ()
         in
           ((i, infdict), result)
         end
@@ -450,7 +407,7 @@ struct
           fun parse_maybeConstraint infdict i =
             if isReserved Token.Colon i orelse isReserved Token.ColonArrow i then
               let
-                val (i, colon) = (i+1, tok i)
+                val (i, colon) = (i + 1, tok i)
                 val (i, sigexp) = consume_sigExp infdict i
               in
                 (i, SOME {colon = colon, sigexp = sigexp})
@@ -460,23 +417,18 @@ struct
 
           fun parse_funarg infdict i =
             if not (check Token.isStrIdentifier i) then
-              let
-                val (i, spec) = consume_sigSpec infdict i
-              in
-                (i, Ast.Fun.ArgSpec spec)
+              let val (i, spec) = consume_sigSpec infdict i
+              in (i, Ast.Fun.ArgSpec spec)
               end
             else
               let
-                val (i, strid) = (i+1, tok i)
+                val (i, strid) = (i + 1, tok i)
                 val (i, colon) = parse_reserved Token.Colon i
                 val (i, sigexp) = consume_sigExp infdict i
               in
                 ( i
                 , Ast.Fun.ArgIdent
-                    { strid = strid
-                    , colon = colon
-                    , sigexp = sigexp
-                    }
+                    {strid = strid, colon = colon, sigexp = sigexp}
                 )
               end
 
@@ -504,15 +456,11 @@ struct
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
-              {parseElem = parseOne, delim = Token.And}
-              i
+              {parseElem = parseOne, delim = Token.And} i
         in
           ( (i, infdict)
           , Ast.FunDec (Ast.Fun.DecFunctor
-              { functorr = functorr
-              , elems = elems
-              , delims = delims
-              })
+              {functorr = functorr, elems = elems, delims = delims})
           )
         end
 
@@ -526,52 +474,51 @@ struct
               , explain = SOME "Expected beginning of top-level declaration."
               }
         in
-          if i >= numToks then err () else
-          let
-            val nextTok = tok i
-            val isMLtonThing =
-              Token.isIdentifier nextTok andalso
-              case Source.toString (Token.getSource nextTok) of
-                "overload" => true
-              | _ => false
-            val _ =
-              if isMLtonThing
-              then ()
-              else err ()
-            val (i, overload) = (i+1, nextTok)
-            val (i, prec) =
-              if check Token.isDecimalIntegerConstant i then
-                (i+1, tok i)
-              else
-                ParserUtils.error
-                  { pos = Token.getSource underscore
-                  , what = "Unexpected token."
-                  , explain = SOME "Expected integer literal."
-                  }
-            val (i, name) = parse_vid i
-            val (i, colon) = parse_reserved Token.Colon i
-            val (i, ty) = parse_ty i
-            val (i, ass) = parse_reserved Token.As i
+          if i >= numToks then
+            err ()
+          else
+            let
+              val nextTok = tok i
+              val isMLtonThing =
+                Token.isIdentifier nextTok
+                andalso
+                case Source.toString (Token.getSource nextTok) of
+                  "overload" => true
+                | _ => false
+              val _ = if isMLtonThing then () else err ()
+              val (i, overload) = (i + 1, nextTok)
+              val (i, prec) =
+                if check Token.isDecimalIntegerConstant i then
+                  (i + 1, tok i)
+                else
+                  ParserUtils.error
+                    { pos = Token.getSource underscore
+                    , what = "Unexpected token."
+                    , explain = SOME "Expected integer literal."
+                    }
+              val (i, name) = parse_vid i
+              val (i, colon) = parse_reserved Token.Colon i
+              val (i, ty) = parse_ty i
+              val (i, ass) = parse_reserved Token.As i
 
-            val (i, {elems, delims}) =
-              parse_oneOrMoreDelimitedByReserved
-                {parseElem = parse_longvid, delim = Token.And}
-                i
-          in
-            ( i
-            , Ast.Str.MLtonOverload
-                { underscore = underscore
-                , overload = overload
-                , prec = prec
-                , name = name
-                , colon = colon
-                , ty = ty
-                , ass = ass
-                , elems = elems
-                , delims = delims
-                }
-            )
-          end
+              val (i, {elems, delims}) =
+                parse_oneOrMoreDelimitedByReserved
+                  {parseElem = parse_longvid, delim = Token.And} i
+            in
+              ( i
+              , Ast.Str.MLtonOverload
+                  { underscore = underscore
+                  , overload = overload
+                  , prec = prec
+                  , name = name
+                  , colon = colon
+                  , ty = ty
+                  , ass = ass
+                  , elems = elems
+                  , delims = delims
+                  }
+              )
+            end
         end
 
 
@@ -579,46 +526,47 @@ struct
         * Top-level
         *)
 
-      fun consume_topDecOne (i, infdict): ((int * InfixDict.t) * Ast.topdec) =
-        if isReserved Token.Signature at i then
-          consume_sigDec (i+1, infdict)
-        else if isReserved Token.Functor at i then
-          consume_fundec infdict (tok i) (i+1)
-        else if check Token.isStrDecStartToken at i orelse
-                check Token.isDecStartToken at i then
-          let
-            val (xx, strdec) = consume_strdec (i, infdict)
-          in
-            (xx, Ast.StrDec strdec)
+      fun consume_topDecOne (i, infdict) : ((int * InfixDict.t) * Ast.topdec) =
+        if
+          isReserved Token.Signature at i
+        then
+          consume_sigDec (i + 1, infdict)
+        else if
+          isReserved Token.Functor at i
+        then
+          consume_fundec infdict (tok i) (i + 1)
+        else if
+          check Token.isStrDecStartToken at i
+          orelse check Token.isDecStartToken at i
+        then
+          let val (xx, strdec) = consume_strdec (i, infdict)
+          in (xx, Ast.StrDec strdec)
           end
-        else if isReserved Token.Underscore i then
-          let
-            val (i, strdec) = consume_MLtonOverload (tok i) (i+1)
-          in
-            ((i, infdict), Ast.StrDec strdec)
+        else if
+          isReserved Token.Underscore i
+        then
+          let val (i, strdec) = consume_MLtonOverload (tok i) (i + 1)
+          in ((i, infdict), Ast.StrDec strdec)
           end
-        else if allowTopExp then
+        else if
+          allowTopExp
+        then
           let
             val (i, exp) =
               ParseExpAndDec.exp toks infdict ExpPatRestriction.None i
-            val (i, semicolon) =
-              ParseSimple.reserved toks Token.Semicolon i
+            val (i, semicolon) = ParseSimple.reserved toks Token.Semicolon i
           in
-            ( (i, infdict)
-            , Ast.TopExp
-                { exp = exp
-                , semicolon = semicolon
-                }
-            )
+            ((i, infdict), Ast.TopExp {exp = exp, semicolon = semicolon})
           end
         else
           ParserUtils.tokError toks
             { pos = i
             , what = "Unexpected token."
             , explain =
-                SOME "Invalid start of top-level declaration. If you want to \
-                     \allow top-level expressions, use the command-line \
-                     \argument `-allow-top-level-exps true`."
+                SOME
+                  "Invalid start of top-level declaration. If you want to \
+                  \allow top-level expressions, use the command-line \
+                  \argument `-allow-top-level-exps true`."
             }
 
       fun parse_topDecMaybeSemicolon (i, infdict) =
@@ -626,19 +574,16 @@ struct
           val ((i, infdict), topdec) = consume_topDecOne (i, infdict)
           val (i, semicolon) = ParseSimple.maybeReserved toks Token.Semicolon i
         in
-          ( (i, infdict)
-          , {topdec = topdec, semicolon = semicolon}
-          )
+          ((i, infdict), {topdec = topdec, semicolon = semicolon})
         end
 
       val ((i, infdict), topdecs) =
-        parse_zeroOrMoreWhile
-          (fn (i, _) => i < numToks)
-          parse_topDecMaybeSemicolon
-          (0, infdict)
+        parse_zeroOrMoreWhile (fn (i, _) => i < numToks)
+          parse_topDecMaybeSemicolon (0, infdict)
 
       val _ =
-        if i >= numToks then ()
+        if i >= numToks then
+          ()
         else
           ParserUtils.error
             { pos = Token.getSource (tok i)
@@ -663,7 +608,8 @@ struct
   fun parse {allowTopExp} src =
     let
       val (_, result) =
-        parseWithInfdict {allowTopExp=allowTopExp} InfixDict.initialTopLevel src
+        parseWithInfdict {allowTopExp = allowTopExp} InfixDict.initialTopLevel
+          src
     in
       result
     end

--- a/src/parse/ParserCombinators.sml
+++ b/src/parse/ParserCombinators.sml
@@ -10,32 +10,23 @@ sig
 
   val zeroOrMoreDelimitedByReserved:
     Token.t Seq.t
-    -> { parseElem: (int, 'a) parser
-       , delim: Token.reserved
-       , shouldStop: int peeker
-       }
+    ->
+      { parseElem: (int, 'a) parser
+      , delim: Token.reserved
+      , shouldStop: int peeker
+      }
     -> (int, {elems: 'a Seq.t, delims: Token.t Seq.t}) parser
 
   val oneOrMoreDelimitedByReserved:
     Token.t Seq.t
-    -> { parseElem: (int, 'a) parser
-       , delim: Token.reserved
-       }
+    -> {parseElem: (int, 'a) parser, delim: Token.reserved}
     -> (int, {elems: 'a Seq.t, delims: Token.t Seq.t}) parser
 
-  val two:
-    ('s, 'a) parser * ('s, 'b) parser
-    -> ('s, ('a * 'b)) parser
+  val two: ('s, 'a) parser * ('s, 'b) parser -> ('s, ('a * 'b)) parser
 
-  val zeroOrMoreWhile:
-    's peeker
-    -> ('s, 'a) parser
-    -> ('s, 'a Seq.t) parser
+  val zeroOrMoreWhile: 's peeker -> ('s, 'a) parser -> ('s, 'a Seq.t) parser
 
-  val oneOrMoreWhile:
-    's peeker
-    -> ('s, 'a) parser
-    -> ('s, 'a Seq.t) parser
+  val oneOrMoreWhile: 's peeker -> ('s, 'a) parser -> ('s, 'a Seq.t) parser
 
 end =
 struct
@@ -47,8 +38,10 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
-      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i =
+        i < numToks andalso f (tok i)
+      fun isReserved rc =
+        check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun loop elems delims i =
         if shouldStop i then
@@ -58,19 +51,13 @@ struct
             val (i, elem) = parseElem i
             val elems = elem :: elems
           in
-            if isReserved delim i then
-              loop elems (tok i :: delims) (i+1)
-            else
-              (i, elems, delims)
+            if isReserved delim i then loop elems (tok i :: delims) (i + 1)
+            else (i, elems, delims)
           end
 
       val (i, elems, delims) = loop [] [] i
     in
-      ( i
-      , { elems = Seq.fromRevList elems
-        , delims = Seq.fromRevList delims
-        }
-      )
+      (i, {elems = Seq.fromRevList elems, delims = Seq.fromRevList delims})
     end
 
 
@@ -78,27 +65,23 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i = i < numToks andalso f (tok i)
-      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i =
+        i < numToks andalso f (tok i)
+      fun isReserved rc =
+        check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun loop elems delims i =
         let
           val (i, elem) = parseElem i
           val elems = elem :: elems
         in
-          if isReserved delim i then
-            loop elems (tok i :: delims) (i+1)
-          else
-            (i, elems, delims)
+          if isReserved delim i then loop elems (tok i :: delims) (i + 1)
+          else (i, elems, delims)
         end
 
       val (i, elems, delims) = loop [] [] i
     in
-      ( i
-      , { elems = Seq.fromRevList elems
-        , delims = Seq.fromRevList delims
-        }
-      )
+      (i, {elems = Seq.fromRevList elems, delims = Seq.fromRevList delims})
     end
 
 
@@ -114,13 +97,15 @@ struct
   fun zeroOrMoreWhile continue parse state =
     let
       fun loop elems state =
-        if not (continue state) then (state, elems) else
-        let
-          val (state, elem) = parse state
-          val elems = elem :: elems
-        in
-          loop elems state
-        end
+        if not (continue state) then
+          (state, elems)
+        else
+          let
+            val (state, elem) = parse state
+            val elems = elem :: elems
+          in
+            loop elems state
+          end
 
       val (state, elems) = loop [] state
     in
@@ -135,10 +120,7 @@ struct
           val (state, elem) = parse state
           val elems = elem :: elems
         in
-          if not (continue state) then
-            (state, elems)
-          else
-            loop elems state
+          if not (continue state) then (state, elems) else loop elems state
         end
 
       val (state, elems) = loop [] state

--- a/src/parse/ParserUtils.sml
+++ b/src/parse/ParserUtils.sml
@@ -6,8 +6,9 @@
 structure ParserUtils:
 sig
   val error: {pos: Source.t, what: string, explain: string option} -> 'a
-  val tokError:
-    Token.t Seq.t -> {pos: int, what: string, explain: string option} -> 'a
+  val tokError: Token.t Seq.t
+                -> {pos: int, what: string, explain: string option}
+                -> 'a
 
   val errorIfInfixNotOpped: InfixDict.t -> Token.t option -> Token.t -> unit
 
@@ -16,12 +17,9 @@ end =
 struct
 
   fun error {what, pos, explain} =
-    raise Error.Error (Error.lineError
-      { header = "PARSE ERROR"
-      , pos = pos
-      , what = what
-      , explain = explain
-      })
+    raise Error.Error
+      (Error.lineError
+         {header = "PARSE ERROR", pos = pos, what = what, explain = explain})
 
   fun tokError toks {what, pos, explain} =
     if pos >= Seq.length toks then
@@ -29,11 +27,7 @@ struct
         val wholeSrc = Source.wholeFile (Token.getSource (Seq.nth toks 0))
         val src = Source.drop wholeSrc (Source.length wholeSrc - 1)
       in
-        error
-          { pos = src
-          , what = "Unexpected end of file."
-          , explain = NONE
-          }
+        error {pos = src, what = "Unexpected end of file.", explain = NONE}
       end
     else
       error
@@ -55,19 +49,21 @@ struct
 
   fun nyi toks fname i =
     if i >= Seq.length toks then
-      raise Error.Error (Error.lineError
-        { header = "ERROR: NOT YET IMPLEMENTED"
-        , pos = Token.getSource (Seq.nth toks (Seq.length toks - 1))
-        , what = "Unexpected EOF after token."
-        , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
-        })
+      raise Error.Error
+        (Error.lineError
+           { header = "ERROR: NOT YET IMPLEMENTED"
+           , pos = Token.getSource (Seq.nth toks (Seq.length toks - 1))
+           , what = "Unexpected EOF after token."
+           , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
+           })
     else if i >= 0 then
-      raise Error.Error (Error.lineError
-        { header = "ERROR: NOT YET IMPLEMENTED"
-        , pos = Token.getSource (Seq.nth toks i)
-        , what = "Unexpected token."
-        , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
-        })
+      raise Error.Error
+        (Error.lineError
+           { header = "ERROR: NOT YET IMPLEMENTED"
+           , pos = Token.getSource (Seq.nth toks i)
+           , what = "Unexpected token."
+           , explain = SOME ("(TODO: see parser " ^ fname ^ ")")
+           })
     else
       raise Fail ("Bug in parser " ^ fname ^ ": position out of bounds??")
 

--- a/src/prettier-print/PrettierFun.sml
+++ b/src/prettier-print/PrettierFun.sml
@@ -16,7 +16,8 @@ struct
   open PrettierStrUtil
   open PrettierStr
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ======================================================================= *)
 
@@ -33,37 +34,30 @@ struct
           (* NOTE: nospace before the colon should be safe here, because
            * structure identifiers cannot be symbolic *)
           at tab
-            (token strid ++
-            (if Token.hasCommentsAfter strid then empty else nospace)
-            ++ token colon
-            ++ showSigExpInDec tab sigexp))
+            (token strid
+             ++ (if Token.hasCommentsAfter strid then empty else nospace)
+             ++ token colon ++ showSigExpInDec tab sigexp))
 
   fun showFunDec tab (Ast.Fun.DecFunctor {functorr, elems, delims}) =
     let
-      fun showFunctor
-            first
-            (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp})
-        =
-          at tab
-            (token starter ++ token funid
-            ++ (if funArgWantsSpaceBefore funarg then
-                  space
-                else
-                  nospace)
-            ++ newTab tab (fn inner =>
-                at inner
-                  (token lparen ++ nospace
-                  ++ showFunArg inner funarg ++ nospace
-                  ++ token rparen))
-            ++ showOption (showConstraintInStrDec tab) constraint
-            ++ token eq
-            ++ (if strExpWantsSameTabAsDec strexp then
-                  at tab (showStrExp tab strexp)
-                else
-                  withNewChild showStrExp tab strexp))
+      fun showFunctor first
+        (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp}) =
+        at tab
+          (token starter ++ token funid
+           ++ (if funArgWantsSpaceBefore funarg then space else nospace)
+           ++
+           newTab tab (fn inner =>
+             at inner
+               (token lparen ++ nospace ++ showFunArg inner funarg ++ nospace
+                ++ token rparen))
+           ++ showOption (showConstraintInStrDec tab) constraint ++ token eq
+           ++
+           (if strExpWantsSameTabAsDec strexp then
+              at tab (showStrExp tab strexp)
+            else
+              withNewChild showStrExp tab strexp))
     in
-      Seq.iterate op++
-        (showFunctor true (functorr, Seq.nth elems 0))
+      Seq.iterate op++ (showFunctor true (functorr, Seq.nth elems 0))
         (Seq.map (showFunctor false) (Seq.zip (delims, Seq.drop elems 1)))
     end
 

--- a/src/prettier-print/PrettierPat.sml
+++ b/src/prettier-print/PrettierPat.sml
@@ -13,7 +13,8 @@ struct
   open PrettierUtil
   open PrettierTy
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ====================================================================== *)
 
@@ -41,38 +42,25 @@ struct
       open Ast.Pat
     in
       case pat of
-        Wild tok =>
-          token tok
+        Wild tok => token tok
 
-      | Const tok =>
-          token tok
+      | Const tok => token tok
 
-      | Unit {left, right} =>
-          token left ++ nospace ++ token right
+      | Unit {left, right} => token left ++ nospace ++ token right
 
-      | Ident {opp, id} =>
-          showMaybeOpToken opp (MaybeLongToken.getToken id)
+      | Ident {opp, id} => showMaybeOpToken opp (MaybeLongToken.getToken id)
 
       | Parens {left, pat, right} =>
-          token left ++
-          (if patStartsWithStar pat then empty else nospace)
+          token left ++ (if patStartsWithStar pat then empty else nospace)
           ++ withNewChild showPat tab pat ++ nospace ++ token right
 
       | Tuple {left, elems, delims, right} =>
           showSequence patStartsWithStar (withNewChild showPat) tab
-            { openn = left
-            , elems = elems
-            , delims = delims
-            , close = right
-            }
+            {openn = left, elems = elems, delims = delims, close = right}
 
       | List {left, elems, delims, right} =>
           showSequence patStartsWithStar (withNewChild showPat) tab
-            { openn = left
-            , elems = elems
-            , delims = delims
-            , close = right
-            }
+            {openn = left, elems = elems, delims = delims, close = right}
 
       | Record {left, elems, delims, right} =>
           let
@@ -84,25 +72,23 @@ struct
                     at inner
                       (token lab ++ token eq ++ withNewChild showPat inner pat))
               | LabAsPat {id, ty, aspat} =>
-                  token id ++
-                  showOption (fn {colon, ty} =>
-                    (if
-                      Token.isSymbolicIdentifier id
-                      orelse Token.hasCommentsBefore colon
-                    then
-                      empty
-                    else
-                      nospace)
-                    ++ token colon ++ withNewChild showTy tab ty) ty ++
-                  showOption (fn {ass, pat} =>
-                    token ass ++ withNewChild showPat tab pat) aspat
+                  token id
+                  ++
+                  showOption
+                    (fn {colon, ty} =>
+                       (if
+                          Token.isSymbolicIdentifier id
+                          orelse Token.hasCommentsBefore colon
+                        then empty
+                        else nospace) ++ token colon
+                       ++ withNewChild showTy tab ty) ty
+                  ++
+                  showOption
+                    (fn {ass, pat} => token ass ++ withNewChild showPat tab pat)
+                    aspat
           in
             showSequence (fn _ => false) (withNewChild showPatRow) tab
-              { openn = left
-              , elems = elems
-              , delims = delims
-              , close = right
-              }
+              {openn = left, elems = elems, delims = delims, close = right}
           end
 
       | Con {opp, id, atpat} =>
@@ -110,29 +96,24 @@ struct
           ++ withNewChild showPat tab atpat
 
       | Typed {pat, colon, ty} =>
-          showPat tab pat ++
-          (if
-            patBeforeColonNeedsSpace pat
-            orelse Token.hasCommentsBefore colon
-          then
-            empty
-          else
-            nospace)
-          ++ token colon ++ withNewChild showTy tab ty
+          showPat tab pat
+          ++
+          (if patBeforeColonNeedsSpace pat orelse Token.hasCommentsBefore colon then
+             empty
+           else
+             nospace) ++ token colon ++ withNewChild showTy tab ty
 
       | Layered {opp, id, ty, ass, pat} =>
-          showMaybeOpToken opp id ++
-          showOption (fn {colon, ty} =>
-            (if
-              Token.isSymbolicIdentifier id
-              orelse Token.hasCommentsBefore colon
-            then
-              empty
-            else
-              nospace)
-            ++ token colon ++ withNewChild showTy tab ty) ty ++
-          token ass ++
-          withNewChild showPat tab pat
+          showMaybeOpToken opp id
+          ++
+          showOption
+            (fn {colon, ty} =>
+               (if
+                  Token.isSymbolicIdentifier id
+                  orelse Token.hasCommentsBefore colon
+                then empty
+                else nospace) ++ token colon ++ withNewChild showTy tab ty) ty
+          ++ token ass ++ withNewChild showPat tab pat
 
       | Infix {left, id, right} =>
           showPat tab left ++ token id ++ withNewChild showPat tab right

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -5,9 +5,10 @@
 
 structure PrettierPrintAst:
 sig
-  val pretty: {ribbonFrac: real, maxWidth: int, tabWidth: int, indent: int, debug: bool}
-           -> Ast.t
-           -> TerminalColorString.t
+  val pretty:
+    {ribbonFrac: real, maxWidth: int, tabWidth: int, indent: int, debug: bool}
+    -> Ast.t
+    -> TerminalColorString.t
 end =
 struct
 
@@ -17,7 +18,8 @@ struct
   open PrettierStr
   open PrettierFun
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ====================================================================== *)
 
@@ -34,8 +36,8 @@ struct
               | Ast.SigDec d => showSigDec tab d
               | Ast.FunDec d => showFunDec tab d
               | Ast.TopExp {exp, semicolon} =>
-                  PrettierExpAndDec.showExp tab exp
-                  ++ nospace ++ token semicolon
+                  PrettierExpAndDec.showExp tab exp ++ nospace
+                  ++ token semicolon
             val sc =
               case semicolon of
                 NONE => empty
@@ -46,20 +48,21 @@ struct
 
         val all = Seq.map (showOneAt root) tds
       in
-        Seq.iterate op++ (Seq.nth all 0)
-          (Seq.map (at root) (Seq.drop all 1))
+        Seq.iterate op++ (Seq.nth all 0) (Seq.map (at root) (Seq.drop all 1))
       end
 
 
   fun pretty (params as {ribbonFrac, maxWidth, tabWidth, indent, debug}) ast =
     let
-      val doc = showAst ast
-      (* val doc = TokenDoc.insertComments doc
-      val doc = TokenDoc.insertBlankLines doc *)
+      val doc = showAst ast (* val doc = TokenDoc.insertComments doc
+                            val doc = TokenDoc.insertBlankLines doc *)
     in
       TabbedStringDoc.pretty
-        {ribbonFrac=ribbonFrac, maxWidth=maxWidth, indentWidth=indent, debug=debug}
-        (toStringDoc {tabWidth=tabWidth, debug=debug} doc)
+        { ribbonFrac = ribbonFrac
+        , maxWidth = maxWidth
+        , indentWidth = indent
+        , debug = debug
+        } (toStringDoc {tabWidth = tabWidth, debug = debug} doc)
     end
 
 end

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -17,7 +17,8 @@ struct
   open PrettierTy
   open PrettierSigUtil
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ======================================================================= *)
 
@@ -26,39 +27,35 @@ struct
    *)
   fun showDatspec tab {datatypee, elems, delims} =
     newTabWithStyle tab (Tab.Style.allowComments, fn tab =>
-    let
-      fun showCon (starter, {vid, arg}) =
-        at tab
-          (starter ++
-          token vid ++
-          showOption
-            (fn {off, ty} =>
-              token off
-              ++ withNewChildWithStyle (indentedAtLeastBy 4) showTy tab ty)
-            arg)
+      let
+        fun showCon (starter, {vid, arg}) =
+          at tab
+            (starter ++ token vid
+             ++
+             showOption
+               (fn {off, ty} =>
+                  token off
+                  ++ withNewChildWithStyle (indentedAtLeastBy 4) showTy tab ty)
+               arg)
 
-      fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
-        let
-          val initial =
-            at tab
-              (token starter ++
-              showTokenSyntaxSeq tab tyvars ++
-              token tycon ++
-              token eq)
+        fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
+          let
+            val initial = at tab
+              (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon
+               ++ token eq)
 
-          val skipper = cond tab {inactive=empty, active=space++space}
-          fun dd delim = token delim ++ space
-        in
-          initial ++
-          Seq.iterate op++
-            (showCon (skipper, Seq.nth elems 0))
-            (Seq.zipWith showCon (Seq.map dd delims, Seq.drop elems 1))
-        end
-    in
-      Seq.iterate op++
-        (showOne (datatypee, Seq.nth elems 0))
-        (Seq.zipWith showOne (delims, Seq.drop elems 1))
-    end)
+            val skipper = cond tab {inactive = empty, active = space ++ space}
+            fun dd delim = token delim ++ space
+          in
+            initial
+            ++
+            Seq.iterate op++ (showCon (skipper, Seq.nth elems 0))
+              (Seq.zipWith showCon (Seq.map dd delims, Seq.drop elems 1))
+          end
+      in
+        Seq.iterate op++ (showOne (datatypee, Seq.nth elems 0))
+          (Seq.zipWith showOne (delims, Seq.drop elems 1))
+      end)
 
   (* ======================================================================= *)
 
@@ -74,18 +71,15 @@ struct
           let
             fun showOne first (starter, {vid, colon, ty}) =
               at tab
-                (token starter ++ token vid ++
-                (if
-                  Token.isSymbolicIdentifier vid
-                  orelse Token.hasCommentsAfter vid
-                then
-                  empty
-                else
-                  nospace)
-                ++ token colon ++ withNewChild showTy tab ty)
+                (token starter ++ token vid
+                 ++
+                 (if
+                    Token.isSymbolicIdentifier vid
+                    orelse Token.hasCommentsAfter vid
+                  then empty
+                  else nospace) ++ token colon ++ withNewChild showTy tab ty)
           in
-            Seq.iterate op++
-              (showOne true (vall, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (vall, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -93,12 +87,9 @@ struct
           let
             fun showOne first (starter, {tyvars, tycon}) =
               at tab
-                (token starter
-                ++ showTokenSyntaxSeq tab tyvars
-                ++ token tycon)
+                (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon)
           in
-            Seq.iterate op++
-              (showOne true (typee, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (typee, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -106,14 +97,10 @@ struct
           let
             fun showOne first (starter, {tyvars, tycon, eq, ty}) =
               at tab
-                (token starter
-                ++ showTokenSyntaxSeq tab tyvars
-                ++ token tycon
-                ++ token eq
-                ++ withNewChild showTy tab ty)
+                (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon
+                 ++ token eq ++ withNewChild showTy tab ty)
           in
-            Seq.iterate op++
-              (showOne true (typee, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (typee, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -121,12 +108,9 @@ struct
           let
             fun showOne first (starter, {tyvars, tycon}) =
               at tab
-                (token starter
-                ++ showTokenSyntaxSeq tab tyvars
-                ++ token tycon)
+                (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon)
           in
-            Seq.iterate op++
-              (showOne true (eqtypee, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (eqtypee, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -135,12 +119,11 @@ struct
             fun showOne first (elem: spec, delim: Token.t option) =
               at tab
                 (showSpec tab elem
-                ++ showOption (fn d => nospace ++ token d) delim)
+                 ++ showOption (fn d => nospace ++ token d) delim)
 
             val things = Seq.zip (elems, delims)
           in
-            Seq.iterate op++
-              (showOne true (Seq.nth things 0))
+            Seq.iterate op++ (showOne true (Seq.nth things 0))
               (Seq.map (showOne false) (Seq.drop things 1))
           end
 
@@ -148,12 +131,12 @@ struct
           let
             fun showOne first (starter, {vid, arg}) =
               at tab
-                (token starter
-                ++ token vid
-                ++ showOption (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg)
+                (token starter ++ token vid
+                 ++
+                 showOption
+                   (fn {off, ty} => token off ++ withNewChild showTy tab ty) arg)
           in
-            Seq.iterate op++
-              (showOne true (exceptionn, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (exceptionn, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -161,17 +144,13 @@ struct
           let
             fun showOne first (starter, {id, colon, sigexp}) =
               at tab
-                (token starter
-                ++ token id
-                (* NOTE: nospace should be safe here, because structure
-                * identifiers cannot be symbolic *)
-                ++ (if Token.hasCommentsAfter id then empty else nospace)
-                ++ token colon)
-              ++
-              showSigExpInDec tab sigexp
+                (token starter ++ token id
+                 (* NOTE: nospace should be safe here, because structure
+                 * identifiers cannot be symbolic *)
+                 ++ (if Token.hasCommentsAfter id then empty else nospace)
+                 ++ token colon) ++ showSigExpInDec tab sigexp
           in
-            Seq.iterate op++
-              (showOne true (structuree, Seq.nth elems 0))
+            Seq.iterate op++ (showOne true (structuree, Seq.nth elems 0))
               (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
           end
 
@@ -179,8 +158,7 @@ struct
           token includee ++ withNewChild showSigExp tab sigexp
 
       | IncludeIds {includee, sigids} =>
-          Seq.iterate op++
-            (token includee)
+          Seq.iterate op++ (token includee)
             (Seq.map (withNewChild (fn _ => token) tab) sigids)
 
       | Sharing {spec, sharingg, elems, delims} =>
@@ -189,18 +167,15 @@ struct
               fun showOne (delim, elem) =
                 at inner
                   (token delim (** this is an '=' *)
-                  ++ token (MaybeLongToken.getToken elem))
+                   ++ token (MaybeLongToken.getToken elem))
 
-              val first =
-                at inner (token (MaybeLongToken.getToken (Seq.nth elems 0)))
+              val first = at inner (token (MaybeLongToken.getToken
+                (Seq.nth elems 0)))
 
-              val stuff =
-                Seq.iterate op++
-                  first
-                  (Seq.zipWith showOne (delims, Seq.drop elems 1))
+              val stuff = Seq.iterate op++ first (Seq.zipWith showOne
+                (delims, Seq.drop elems 1))
             in
-              showSpec tab spec ++
-              at tab (token sharingg ++ stuff)
+              showSpec tab spec ++ at tab (token sharingg ++ stuff)
             end)
 
       | SharingType {spec, sharingg, typee, elems, delims} =>
@@ -209,32 +184,27 @@ struct
               fun showOne (delim, elem) =
                 at inner
                   (token delim (** this is an '=' *)
-                  ++ token (MaybeLongToken.getToken elem))
+                   ++ token (MaybeLongToken.getToken elem))
 
-              val first =
-                at inner (token (MaybeLongToken.getToken (Seq.nth elems 0)))
+              val first = at inner (token (MaybeLongToken.getToken
+                (Seq.nth elems 0)))
 
-              val stuff =
-                Seq.iterate op++
-                  first
-                  (Seq.zipWith showOne (delims, Seq.drop elems 1))
+              val stuff = Seq.iterate op++ first (Seq.zipWith showOne
+                (delims, Seq.drop elems 1))
             in
-              showSpec tab spec ++
-              at tab (token sharingg ++ token typee ++ stuff)
+              showSpec tab spec
+              ++ at tab (token sharingg ++ token typee ++ stuff)
             end)
 
       | ReplicateDatatype
-        {left_datatypee, left_id, eq, right_datatypee, right_id} =>
-          token left_datatypee
-          ++ token left_id
-          ++ token eq
-          ++ newTab tab (fn inner =>
-              at inner
-              (token right_datatypee
-              ++ token (MaybeLongToken.getToken right_id)))
+          {left_datatypee, left_id, eq, right_datatypee, right_id} =>
+          token left_datatypee ++ token left_id ++ token eq
+          ++
+          newTab tab (fn inner =>
+            at inner
+              (token right_datatypee ++ token (MaybeLongToken.getToken right_id)))
 
-      | Datatype xxx =>
-          showDatspec tab xxx
+      | Datatype xxx => showDatspec tab xxx
     end
 
 
@@ -243,34 +213,23 @@ struct
       open Ast.Sig
     in
       case sigexp of
-        Ident id =>
-          token id
+        Ident id => token id
 
       | Spec {sigg, spec, endd} =>
           newTabWithStyle tab (indented, fn inner =>
-            at tab (token sigg)
-            ++
-            at inner (showSpec inner spec)
-            ++
-            cond inner
-              { inactive = token endd
-              , active = at tab (token endd)
-              })
+            at tab (token sigg) ++ at inner (showSpec inner spec)
+            ++ cond inner {inactive = token endd, active = at tab (token endd)})
 
       | WhereType {sigexp, elems} =>
           let
             fun showElem {wheree, typee, tyvars, tycon, eq, ty} =
               at tab
-                (token wheree (** this could be 'and' *)
-                ++ token typee
-                ++ showTokenSyntaxSeq tab tyvars
-                ++ token (MaybeLongToken.getToken tycon)
-                ++ token eq
-                ++ withNewChild showTy tab ty)
+                (token wheree (** this could be 'and' *) ++ token typee
+                 ++ showTokenSyntaxSeq tab tyvars
+                 ++ token (MaybeLongToken.getToken tycon) ++ token eq
+                 ++ withNewChild showTy tab ty)
           in
-            Seq.iterate op++
-              (showSigExp tab sigexp)
-              (Seq.map showElem elems)
+            Seq.iterate op++ (showSigExp tab sigexp) (Seq.map showElem elems)
           end
     end
 
@@ -279,38 +238,28 @@ struct
     if not (sigExpWantsSameTabAsDec sigexp) then
       withNewChild showSigExp tab sigexp
     else
-    let
-      open Ast.Sig
-      val style = Tab.Style.combine (Tab.Style.rigid, Tab.Style.indented)
-    in
-      case sigexp of
-        Spec {sigg, spec, endd} =>
-          newTabWithStyle tab (style, fn inner =>
-            at tab (token sigg)
-            ++
-            at inner (showSpec inner spec)
-            ++
-            cond inner
-              { inactive = token endd
-              , active = at tab (token endd)
-              })
+      let
+        open Ast.Sig
+        val style = Tab.Style.combine (Tab.Style.rigid, Tab.Style.indented)
+      in
+        case sigexp of
+          Spec {sigg, spec, endd} =>
+            newTabWithStyle tab (style, fn inner =>
+              at tab (token sigg) ++ at inner (showSpec inner spec)
+              ++
+              cond inner {inactive = token endd, active = at tab (token endd)})
 
-      | _ => at tab (showSigExp tab sigexp)
-    end
+        | _ => at tab (showSigExp tab sigexp)
+      end
 
 
   and showSigDec tab (Ast.Sig.Signature {signaturee, elems, delims}) =
     let
       fun showOne first (starter, {ident, eq, sigexp}) =
-        at tab
-          (token starter
-          ++ token ident
-          ++ token eq)
-        ++
-        showSigExpInDec tab sigexp
+        at tab (token starter ++ token ident ++ token eq)
+        ++ showSigExpInDec tab sigexp
     in
-      Seq.iterate op++
-        (showOne true (signaturee, Seq.nth elems 0))
+      Seq.iterate op++ (showOne true (signaturee, Seq.nth elems 0))
         (Seq.zipWith (showOne false) (delims, Seq.drop elems 1))
     end
 

--- a/src/prettier-print/PrettierSigUtil.sml
+++ b/src/prettier-print/PrettierSigUtil.sml
@@ -14,7 +14,8 @@ struct
   open TabbedTokenDoc
   open PrettierUtil
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ====================================================================== *)
 

--- a/src/prettier-print/PrettierStr.sml
+++ b/src/prettier-print/PrettierStr.sml
@@ -18,7 +18,8 @@ struct
   open PrettierSig
   open PrettierStrUtil
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ====================================================================== *)
 
@@ -26,25 +27,22 @@ struct
     let
       open Ast.Str
     in
-      case e of
-        Ident id =>
-          token (MaybeLongToken.getToken id)
+      case
+        e
+      of
+        Ident id => token (MaybeLongToken.getToken id)
 
       | Struct {structt, strdec, endd} =>
           if strDecIsEmpty strdec then
             token structt ++ at tab (token endd)
           else
             newTabWithStyle tab (indented, fn inner =>
-              token structt
-              ++ at inner (showStrDec inner strdec)
-              ++ cond inner
-                { inactive = token endd
-                , active = at tab (token endd)
-                })
+              token structt ++ at inner (showStrDec inner strdec)
+              ++
+              cond inner {inactive = token endd, active = at tab (token endd)})
 
       | Constraint {strexp, colon, sigexp} =>
-          showStrExp tab strexp
-          ++ token colon
+          showStrExp tab strexp ++ token colon
           ++ withNewChild showSigExp tab sigexp
 
       | FunAppExp {funid, lparen, strexp, rparen} =>
@@ -55,28 +53,25 @@ struct
            * open to debate.)
            *)
           newTab tab (fn inner =>
-            token funid ++
-            (if strExpInsideFunAppWantsSpaceBefore strexp then
-               space
-             else
-               nospace) ++
+            token funid
+            ++
+            (if strExpInsideFunAppWantsSpaceBefore strexp then space
+             else nospace)
+            ++
             at inner
-              (token lparen ++ nospace
-              ++ withNewChild showStrExp inner strexp
-              ++ nospace ++ token rparen))
+              (token lparen ++ nospace ++ withNewChild showStrExp inner strexp
+               ++ nospace ++ token rparen))
 
-      | FunAppDec {funid, lparen, strdec, rparen} =>
-          (* See note above, about the maybe-space after `funid` *)
+      | FunAppDec {funid, lparen, strdec, rparen} => (* See note above, about the maybe-space after `funid` *)
           newTab tab (fn inner =>
-            token funid ++
-            (if strDecInsideFunAppWantsSpaceBefore strdec then
-               space
-             else
-               nospace) ++
+            token funid
+            ++
+            (if strDecInsideFunAppWantsSpaceBefore strdec then space
+             else nospace)
+            ++
             at inner
-              (token lparen ++ nospace
-              ++ withNewChild showStrDec inner strdec
-              ++ nospace ++ token rparen))
+              (token lparen ++ nospace ++ withNewChild showStrDec inner strdec
+               ++ nospace ++ token rparen))
 
       | LetInEnd {lett, strdec, inn, strexp, endd} =>
           showThingSimilarToLetInEnd tab
@@ -95,36 +90,33 @@ struct
       open Ast.Str
     in
       case d of
-        DecEmpty =>
-          empty
+        DecEmpty => empty
 
-      | DecCore d =>
-          showDec tab d
+      | DecCore d => showDec tab d
 
       | DecStructure {structuree, elems, delims} =>
           newTab tab (fn tab =>
-          let
-            fun showConstraint constraint =
-              case constraint of
-                NONE => empty
-              | SOME {colon, sigexp} =>
-                  showConstraintInStrDec tab {colon=colon, sigexp=sigexp}
+            let
+              fun showConstraint constraint =
+                case constraint of
+                  NONE => empty
+                | SOME {colon, sigexp} =>
+                    showConstraintInStrDec tab {colon = colon, sigexp = sigexp}
 
-            fun showOne (starter, {strid, constraint, eq, strexp}) =
-              token starter
-              ++ token strid
-              ++ showConstraint constraint
-              ++ token eq
-              ++ (if strExpWantsSameTabAsDec strexp then
-                    at tab (showStrExp tab strexp)
-                  else
-                    withNewChild showStrExp tab strexp)
-          in
-            at tab (Seq.iterate op++
-              (showOne (structuree, Seq.nth elems 0))
-              (Seq.map (fn x => at tab (showOne x))
-                (Seq.zip (delims, (Seq.drop elems 1)))))
-          end)
+              fun showOne (starter, {strid, constraint, eq, strexp}) =
+                token starter ++ token strid ++ showConstraint constraint
+                ++ token eq
+                ++
+                (if strExpWantsSameTabAsDec strexp then
+                   at tab (showStrExp tab strexp)
+                 else
+                   withNewChild showStrExp tab strexp)
+            in
+              at tab
+                (Seq.iterate op++ (showOne (structuree, Seq.nth elems 0))
+                   (Seq.map (fn x => at tab (showOne x)) (Seq.zip
+                      (delims, (Seq.drop elems 1)))))
+            end)
 
 
       | DecMultiple {elems, delims} =>
@@ -132,13 +124,12 @@ struct
             fun mk first (elem, delim) =
               at tab
                 (showStrDec tab elem
-                ++ showOption (fn d => nospace ++ token d) delim)
+                 ++ showOption (fn d => nospace ++ token d) delim)
 
             val things = Seq.zip (elems, delims)
           in
-            Seq.iterate op++
-              (mk true (Seq.nth things 0))
-              (Seq.map (mk false) (Seq.drop things 1))
+            Seq.iterate op++ (mk true (Seq.nth things 0)) (Seq.map (mk false)
+              (Seq.drop things 1))
           end
 
       | DecLocalInEnd {locall, strdec1, inn, strdec2, endd} =>
@@ -154,30 +145,25 @@ struct
       (** This is MLton-specific. Useful for testing by parsing the entire
         * MLton implementation of the standard basis.
         *)
-      | MLtonOverload {underscore, overload, prec, name, colon, ty, ass, elems, delims} =>
+      | MLtonOverload
+          {underscore, overload, prec, name, colon, ty, ass, elems, delims} =>
           newTab tab (fn inner =>
             let
               val front =
                 at inner
-                  (token underscore ++ nospace ++ token overload
-                  ++ token prec
-                  ++ token name
-                  ++ token colon)
-                ++ withNewChild showTy inner ty
+                  (token underscore ++ nospace ++ token overload ++ token prec
+                   ++ token name ++ token colon) ++ withNewChild showTy inner ty
                 ++
                 at inner
                   (token ass
-                  ++ token (MaybeLongToken.getToken (Seq.nth elems 0)))
+                   ++ token (MaybeLongToken.getToken (Seq.nth elems 0)))
 
               fun showOne (d, e) =
                 at inner (token d ++ token (MaybeLongToken.getToken e))
             in
-              Seq.iterate op++
-                front
-                (Seq.zipWith showOne (delims, Seq.drop elems 1))
-            end)
-
-      (* | _ => text "<strdec>" *)
+              Seq.iterate op++ front (Seq.zipWith showOne
+                (delims, Seq.drop elems 1))
+            end) (* | _ => text "<strdec>" *)
     end
 
 end

--- a/src/prettier-print/PrettierStrUtil.sml
+++ b/src/prettier-print/PrettierStrUtil.sml
@@ -10,7 +10,8 @@ sig
   val strExpInsideFunAppWantsSpaceBefore: Ast.Str.strexp -> bool
   val strDecInsideFunAppWantsSpaceBefore: Ast.Str.strdec -> bool
   val strDecIsEmpty: Ast.Str.strdec -> bool
-  val showConstraintInStrDec: {colon: Token.t, sigexp: Ast.Sig.sigexp} PrettierUtil.shower
+  val showConstraintInStrDec:
+    {colon: Token.t, sigexp: Ast.Sig.sigexp} PrettierUtil.shower
 end =
 struct
 
@@ -19,7 +20,8 @@ struct
   open PrettierSigUtil
   open PrettierSig
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   (* ====================================================================== *)
 
@@ -74,15 +76,9 @@ struct
 
   fun showConstraintInStrDec tab {colon, sigexp} =
     (if
-      Token.getClass colon = Token.Reserved Token.ColonArrow
-      orelse Token.hasCommentsBefore colon
-    then
-      empty
-    else
-      nospace)
-    ++
-    token colon
-    ++
-    showSigExpInDec tab sigexp
+       Token.getClass colon = Token.Reserved Token.ColonArrow
+       orelse Token.hasCommentsBefore colon
+     then empty
+     else nospace) ++ token colon ++ showSigExpInDec tab sigexp
 
 end

--- a/src/prettier-print/PrettierTy.sml
+++ b/src/prettier-print/PrettierTy.sml
@@ -12,15 +12,15 @@ struct
   open TabbedTokenDoc
   open PrettierUtil
   infix 2 ++
-  fun x ++ y = concat (x, y)
+  fun x ++ y =
+    concat (x, y)
 
   fun showTy tab ty : doc =
     let
       open Ast.Ty
     in
       case ty of
-        Var tok =>
-          token tok
+        Var tok => token tok
 
       | Con {args = Ast.SyntaxSeq.Empty, id} =>
           token (MaybeLongToken.getToken id)
@@ -30,12 +30,14 @@ struct
           ++ token (MaybeLongToken.getToken id)
 
       | Parens {left, ty, right} =>
-          token left ++ nospace ++ withNewChild showTy tab ty ++ nospace ++ token right
+          token left ++ nospace ++ withNewChild showTy tab ty ++ nospace
+          ++ token right
 
       | Tuple {elems, delims} =>
           newTab tab (fn tab =>
             let
-              fun f (delim, x) = at tab (token delim ++ withNewChild showTy tab x)
+              fun f (delim, x) =
+                at tab (token delim ++ withNewChild showTy tab x)
             in
               Seq.iterate op++
                 (at tab (withNewChild showTy tab (Seq.nth elems 0)))
@@ -45,34 +47,28 @@ struct
       | Record {left, elems, delims, right} =>
           let
             fun showElem tab {lab, colon, ty} =
-              token lab ++
+              token lab
+              ++
               (if
-                Token.isSymbolicIdentifier lab
-                orelse Token.hasCommentsAfter lab
-              then
-                empty
-              else
-                nospace)
-              ++ token colon ++ showTy tab ty
+                 Token.isSymbolicIdentifier lab
+                 orelse Token.hasCommentsAfter lab
+               then empty
+               else nospace) ++ token colon ++ showTy tab ty
           in
             showSequence (fn _ => false) (withNewChild showElem) tab
-              { openn = left
-              , elems = elems
-              , delims = delims
-              , close = right
-              }
+              {openn = left, elems = elems, delims = delims, close = right}
           end
 
       | Arrow {from, arrow, to} =>
           let
             fun loop (arr, right) =
-              at tab (token arr ++
-                (case right of
-                  Arrow {from, arrow, to} =>
-                    withNewChild showTy tab from
-                    ++ loop (arrow, to)
-                | _ =>
-                    withNewChild showTy tab right))
+              at tab
+                (token arr
+                 ++
+                 (case right of
+                    Arrow {from, arrow, to} =>
+                      withNewChild showTy tab from ++ loop (arrow, to)
+                  | _ => withNewChild showTy tab right))
           in
             withNewChild showTy tab from ++ loop (arrow, to)
           end

--- a/src/prettier-print/TabbedStringDoc.sml
+++ b/src/prettier-print/TabbedStringDoc.sml
@@ -1,37 +1,31 @@
 structure TabbedStringDoc =
-  PrettyTabbedDoc(struct
-    open TerminalColorString
+  PrettyTabbedDoc
+    (struct
+       open TerminalColorString
 
-    val compaction = CommandLineArgs.parseReal "s-compact" 1.1 (* must be >= 1 *)
-    val maxSat = CommandLineArgs.parseReal "s-max" 0.6
+       val compaction =
+         CommandLineArgs.parseReal "s-compact" 1.1 (* must be >= 1 *)
+       val maxSat = CommandLineArgs.parseReal "s-max" 0.6
 
-    val hues = Seq.fromList
-      [ 0
-      , 30
-      , 55
-      , 90
-      , 140
-      , 180
-      , 210
-      , 250
-      , 290
-      , 320
-      ]
+       val hues = Seq.fromList [0, 30, 55, 90, 140, 180, 210, 250, 290, 320]
 
-    fun niceRed depth =
-      let
-        val s = (compaction-1.0 +
-          (1.0 / (1.0 + (Real.fromInt depth / compaction)))) / compaction
-        val s = s * maxSat
+       fun niceRed depth =
+         let
+           val s =
+             (compaction - 1.0
+              + (1.0 / (1.0 + (Real.fromInt depth / compaction)))) / compaction
+           val s = s * maxSat
 
-        (* val d = if depth mod 2 = 0 then 2*(depth div 2)+1 else 2*(depth div 2) *)
-        val d = 3*(depth-1)
-        val h = Real.fromInt (Seq.nth hues (d mod Seq.length hues))
-      in
-        TerminalColors.hsv {h=h, s=s, v=0.9}
-      end
+           (* val d = if depth mod 2 = 0 then 2*(depth div 2)+1 else 2*(depth div 2) *)
+           val d = 3 * (depth - 1)
+           val h = Real.fromInt (Seq.nth hues (d mod Seq.length hues))
+         in
+           TerminalColors.hsv {h = h, s = s, v = 0.9}
+         end
 
-    fun emphasize depth s = backgroundIfNone (niceRed depth) s
+       fun emphasize depth s =
+         backgroundIfNone (niceRed depth) s
 
-    fun toString t = TerminalColorString.toString {colors=false} t
-  end)
+       fun toString t =
+         TerminalColorString.toString {colors = false} t
+     end)

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -28,7 +28,9 @@ sig
 
   val toStringDoc: {tabWidth: int, debug: bool} -> doc -> TabbedStringDoc.t
 
-  val justCommentsToStringDoc: {tabWidth: int} -> Token.t Seq.t -> TabbedStringDoc.t
+  val justCommentsToStringDoc: {tabWidth: int}
+                               -> Token.t Seq.t
+                               -> TabbedStringDoc.t
 end =
 struct
 
@@ -64,7 +66,8 @@ struct
   val token = Token
   val text = Text
   val var = Var
-  fun at t d = At (t, d)
+  fun at t d =
+    At (t, d)
 
   fun concat (d1, d2) =
     case (d1, d2) of
@@ -72,7 +75,8 @@ struct
     | (_, Empty) => d1
     | _ => Concat (d1, d2)
 
-  fun cond tab {inactive, active} = Cond {tab=tab, inactive=inactive, active=active}
+  fun cond tab {inactive, active} =
+    Cond {tab = tab, inactive = inactive, active = active}
 
   fun toString doc =
     case doc of
@@ -83,13 +87,15 @@ struct
     | Token t => "Token('" ^ Token.toString t ^ "')"
     | Text t => "Text('" ^ t ^ "')"
     | At (t, d) => "At(" ^ Tab.toString t ^ "," ^ toString d ^ ")"
-    | NewTab {tab=t, doc=d, ...} => "NewTab(" ^ Tab.toString t ^ ", " ^ toString d ^ ")"
-    | Cond {tab=t, inactive=df, active=dnf} =>
-        "Cond(" ^ Tab.toString t ^ ", " ^ toString df ^ ", " ^ toString dnf ^ ")"
-    | LetDoc {var, doc=d, inn} =>
-        "LetDoc(" ^ DocVar.toString var ^ ", " ^ toString d ^ ", " ^ toString inn ^ ")"
-    | Var v =>
-        "Var(" ^ DocVar.toString v ^ ")"
+    | NewTab {tab = t, doc = d, ...} =>
+        "NewTab(" ^ Tab.toString t ^ ", " ^ toString d ^ ")"
+    | Cond {tab = t, inactive = df, active = dnf} =>
+        "Cond(" ^ Tab.toString t ^ ", " ^ toString df ^ ", " ^ toString dnf
+        ^ ")"
+    | LetDoc {var, doc = d, inn} =>
+        "LetDoc(" ^ DocVar.toString var ^ ", " ^ toString d ^ ", "
+        ^ toString inn ^ ")"
+    | Var v => "Var(" ^ DocVar.toString v ^ ")"
 
   fun letdoc d f =
     let
@@ -101,13 +107,14 @@ struct
 
   fun newTabWithStyle parent (style, genDocUsingTab: tab -> doc) =
     let
-      val t = Tab.new {parent=parent, style=style}
+      val t = Tab.new {parent = parent, style = style}
       val d = genDocUsingTab t
     in
-      NewTab {tab=t, doc=d}
+      NewTab {tab = t, doc = d}
     end
 
-  fun newTab parent f = newTabWithStyle parent (Tab.Style.inplace, f)
+  fun newTab parent f =
+    newTabWithStyle parent (Tab.Style.inplace, f)
 
   (* ====================================================================== *)
   (* ====================================================================== *)
@@ -135,17 +142,19 @@ struct
     | AnnSpace => "_"
     | AnnNoSpace => "NoSpace"
     | AnnConcat (d1, d2) => annToString d1 ^ " ++ " ^ annToString d2
-    | AnnToken {tok=t, ...} => "Token('" ^ Token.toString t ^ "')"
-    | AnnText {txt=t, ...} => "Text('" ^ t ^ "')"
+    | AnnToken {tok = t, ...} => "Token('" ^ Token.toString t ^ "')"
+    | AnnText {txt = t, ...} => "Text('" ^ t ^ "')"
     | AnnAt {tab, doc} =>
         "At(" ^ Tab.toString tab ^ ", " ^ annToString doc ^ ")"
-    | AnnNewTab {tab=t, doc=d, ...} => "NewTab(" ^ Tab.toString t ^ ", " ^ annToString d ^ ")"
-    | AnnCond {tab=t, inactive=df, active=dnf} =>
-        "Cond(" ^ Tab.toString t ^ ", " ^ annToString df ^ ", " ^ annToString dnf ^ ")"
-    | AnnLetDoc {var, doc=d, inn} =>
-        "LetDoc(" ^ DocVar.toString var ^ ", " ^ annToString d ^ ", " ^ annToString inn ^ ")"
-    | AnnVar v =>
-        "Var(" ^ DocVar.toString v ^ ")"
+    | AnnNewTab {tab = t, doc = d, ...} =>
+        "NewTab(" ^ Tab.toString t ^ ", " ^ annToString d ^ ")"
+    | AnnCond {tab = t, inactive = df, active = dnf} =>
+        "Cond(" ^ Tab.toString t ^ ", " ^ annToString df ^ ", "
+        ^ annToString dnf ^ ")"
+    | AnnLetDoc {var, doc = d, inn} =>
+        "LetDoc(" ^ DocVar.toString var ^ ", " ^ annToString d ^ ", "
+        ^ annToString inn ^ ")"
+    | AnnVar v => "Var(" ^ DocVar.toString v ^ ")"
 
 
   fun annConcat (d1, d2) =
@@ -163,17 +172,14 @@ struct
           Empty => AnnEmpty
         | Space => AnnSpace
         | NoSpace => AnnNoSpace
-        | Token t => AnnToken {at=NONE, tok=t}
-        | Text t => AnnText {at=NONE, txt=t}
+        | Token t => AnnToken {at = NONE, tok = t}
+        | Text t => AnnText {at = NONE, txt = t}
         | Var v => AnnVar v
         | LetDoc {var, doc, inn} =>
-            AnnLetDoc {var=var, doc = loop doc, inn = loop inn}
-        | At (tab, doc) =>
-            AnnAt {tab = tab, doc = loop doc}
-        | Concat (d1, d2) =>
-            AnnConcat (loop d1, loop d2)
-        | NewTab {tab, doc} =>
-            AnnNewTab {tab = tab, doc = loop doc}
+            AnnLetDoc {var = var, doc = loop doc, inn = loop inn}
+        | At (tab, doc) => AnnAt {tab = tab, doc = loop doc}
+        | Concat (d1, d2) => AnnConcat (loop d1, loop d2)
+        | NewTab {tab, doc} => AnnNewTab {tab = tab, doc = loop doc}
         | Cond {tab, inactive, active} =>
             AnnCond {tab = tab, inactive = loop inactive, active = loop active}
 
@@ -189,8 +195,7 @@ struct
   fun ensureSpaces debug (doc: anndoc) =
     let
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
       datatype edge = Spacey | MaybeNotSpacey
 
@@ -225,24 +230,18 @@ struct
                   (SOME MaybeNotSpacey, SOME MaybeNotSpacey) =>
                     AnnConcat (AnnConcat (d1, AnnSpace), d2)
                 | _ => AnnConcat (d1, d2)
-              val left =
-                if Option.isSome left then left else rightleft
-              val right =
-                if Option.isSome right then right else leftright
+              val left = if Option.isSome left then left else rightleft
+              val right = if Option.isSome right then right else leftright
             in
               (left, doc, right)
             end
         | AnnAt {tab, doc} =>
-            let
-              val (left, doc, right) = loop vars doc
-            in
-              (left, AnnAt {tab=tab, doc=doc}, right)
+            let val (left, doc, right) = loop vars doc
+            in (left, AnnAt {tab = tab, doc = doc}, right)
             end
         | AnnNewTab {tab, doc} =>
-            let
-              val (left, doc, right) = loop vars doc
-            in
-              (left, AnnNewTab {tab=tab, doc=doc}, right)
+            let val (left, doc, right) = loop vars doc
+            in (left, AnnNewTab {tab = tab, doc = doc}, right)
             end
         | AnnCond {tab, active, inactive} =>
             let
@@ -250,7 +249,7 @@ struct
               val (left2, inactive, right2) = loop vars inactive
             in
               ( edgeOptUnion (left1, left2)
-              , AnnCond {tab=tab, active=active, inactive=inactive}
+              , AnnCond {tab = tab, active = active, inactive = inactive}
               , edgeOptUnion (right1, right2)
               )
             end
@@ -260,16 +259,11 @@ struct
               val vars = VarDict.insert vars (var, (left, right))
               val (left, inn, right) = loop vars inn
             in
-              ( left
-              , AnnLetDoc {var=var, doc=doc, inn=inn}
-              , right
-              )
+              (left, AnnLetDoc {var = var, doc = doc, inn = inn}, right)
             end
         | AnnVar v =>
-            let
-              val (left, right) = VarDict.lookup vars v
-            in
-              (left, doc, right)
+            let val (left, right) = VarDict.lookup vars v
+            in (left, doc, right)
             end
 
       val (_, doc, _) = loop VarDict.empty doc
@@ -289,8 +283,13 @@ struct
         val s1 = Token.getSource t1
         val s2 = Token.getSource t2
       in
-        case Int.compare (Source.absoluteStartOffset s1, Source.absoluteStartOffset s2) of
-          EQUAL => Int.compare (Source.absoluteEndOffset s1, Source.absoluteEndOffset s2)
+        case
+          Int.compare
+            (Source.absoluteStartOffset s1, Source.absoluteStartOffset s2)
+        of
+          EQUAL =>
+            Int.compare
+              (Source.absoluteEndOffset s1, Source.absoluteEndOffset s2)
         | other => other
       end
   end
@@ -305,8 +304,7 @@ struct
   fun flowAts debug (doc: anndoc) =
     let
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
       datatype tab_constraint = Active | Inactive
       type context = tab_constraint TabDict.t
@@ -317,8 +315,7 @@ struct
       fun markActive ctx tab =
         case Tab.parent tab of
           NONE => ctx
-        | SOME p =>
-            markActive (TabDict.insert ctx (tab, Active)) p
+        | SOME p => markActive (TabDict.insert ctx (tab, Active)) p
 
       fun flowunion (flow1, flow2) =
         case (flow1, flow2) of
@@ -335,24 +332,28 @@ struct
         | AnnToken {tok, ...} =>
             let
               val _ =
-                Option.app (fn ts =>
-                  dbgprintln
-                    ("token '" ^ Token.toString tok ^ "' at: " ^
-                     String.concatWith " " (List.map Tab.toString (TabSet.listKeys ts))))
-                flowval
+                Option.app
+                  (fn ts =>
+                     dbgprintln
+                       ("token '" ^ Token.toString tok ^ "' at: "
+                        ^
+                        String.concatWith " "
+                          (List.map Tab.toString (TabSet.listKeys ts)))) flowval
             in
-              (NONE, vars, AnnToken {tok=tok, at=flowval})
+              (NONE, vars, AnnToken {tok = tok, at = flowval})
             end
         | AnnText {txt, ...} =>
             let
               val _ =
-                Option.app (fn ts =>
-                  dbgprintln
-                    ("text '" ^ txt ^ "' at: " ^
-                     String.concatWith " " (List.map Tab.toString (TabSet.listKeys ts))))
-                flowval
+                Option.app
+                  (fn ts =>
+                     dbgprintln
+                       ("text '" ^ txt ^ "' at: "
+                        ^
+                        String.concatWith " "
+                          (List.map Tab.toString (TabSet.listKeys ts)))) flowval
             in
-              (NONE, vars, AnnText {txt=txt, at=flowval})
+              (NONE, vars, AnnText {txt = txt, at = flowval})
             end
         | AnnAt {tab, doc} =>
             let
@@ -360,7 +361,7 @@ struct
               val flowval = flowunion (flowval, SOME (TabSet.singleton tab))
               val (_, vars, doc) = loop ctx (flowval, vars, doc)
             in
-              (NONE, vars, AnnAt {tab=tab, doc=doc})
+              (NONE, vars, AnnAt {tab = tab, doc = doc})
             end
         | AnnConcat (d1, d2) =>
             let
@@ -370,60 +371,63 @@ struct
               (flowval, vars, AnnConcat (d1, d2))
             end
         | AnnNewTab {tab, doc} =>
-            let
-              val (flowval, vars, doc) = loop ctx (flowval, vars, doc)
-            in
-              (flowval, vars, AnnNewTab {tab=tab, doc=doc})
+            let val (flowval, vars, doc) = loop ctx (flowval, vars, doc)
+            in (flowval, vars, AnnNewTab {tab = tab, doc = doc})
             end
         | AnnCond {tab, active, inactive} =>
             (case TabDict.find ctx tab of
-              SOME Active => loop ctx (flowval, vars, active)
-            | SOME Inactive => loop ctx (flowval, vars, inactive)
-            | _ =>
-                let
-                  val (flow1, vars, inactive) = loop (markInactive ctx tab) (flowval, vars, inactive)
-                  val (flow2, vars, active) = loop (markActive ctx tab) (flowval, vars, active)
-                  val flowval =
-                    (* TODO: is union necessary here? *)
-                    flowunion (flow1, flow2)
-                in
-                  (flowval, vars, AnnCond {tab=tab, active=active, inactive=inactive})
-                end)
+               SOME Active => loop ctx (flowval, vars, active)
+             | SOME Inactive => loop ctx (flowval, vars, inactive)
+             | _ =>
+                 let
+                   val (flow1, vars, inactive) = loop (markInactive ctx tab)
+                     (flowval, vars, inactive)
+                   val (flow2, vars, active) = loop (markActive ctx tab)
+                     (flowval, vars, active)
+                   val flowval = (* TODO: is union necessary here? *) flowunion
+                     (flow1, flow2)
+                 in
+                   ( flowval
+                   , vars
+                   , AnnCond {tab = tab, active = active, inactive = inactive}
+                   )
+                 end)
         | AnnLetDoc {var, doc, inn} =>
             let
               val vars = VarDict.insert vars (var, NONE)
               val (flowval, vars, inn) = loop ctx (flowval, vars, inn)
             in
-              (flowval, vars, AnnLetDoc {var=var, doc=doc, inn=inn})
+              (flowval, vars, AnnLetDoc {var = var, doc = doc, inn = inn})
             end
         | AnnVar v =>
             let
-              val vars =
-                VarDict.insert vars (v, flowunion (VarDict.lookup vars v, flowval))
+              val vars = VarDict.insert vars (v, flowunion
+                (VarDict.lookup vars v, flowval))
             in
               (NONE, vars, AnnVar v)
             end
 
-      val (_, varinfo, doc) =
-        loop TabDict.empty (SOME (TabSet.singleton root), VarDict.empty, doc)
+      val (_, varinfo, doc) = loop TabDict.empty
+        (SOME (TabSet.singleton root), VarDict.empty, doc)
 
       fun updateVars doc =
         case doc of
-          AnnLetDoc {var, doc=d, inn} =>
+          AnnLetDoc {var, doc = d, inn} =>
             let
               val flowval = VarDict.lookup varinfo var
               val (_, _, d) = loop TabDict.empty (flowval, varinfo, d)
             in
-              AnnLetDoc {var=var, doc=d, inn = updateVars inn}
+              AnnLetDoc {var = var, doc = d, inn = updateVars inn}
             end
-        | AnnConcat (d1, d2) =>
-            AnnConcat (updateVars d1, updateVars d2)
-        | AnnAt {tab, doc} =>
-            AnnAt {tab=tab, doc = updateVars doc}
+        | AnnConcat (d1, d2) => AnnConcat (updateVars d1, updateVars d2)
+        | AnnAt {tab, doc} => AnnAt {tab = tab, doc = updateVars doc}
         | AnnCond {tab, inactive, active} =>
-            AnnCond {tab=tab, inactive = updateVars inactive, active = updateVars active}
-        | AnnNewTab {tab, doc} =>
-            AnnNewTab {tab=tab, doc = updateVars doc}
+            AnnCond
+              { tab = tab
+              , inactive = updateVars inactive
+              , active = updateVars active
+              }
+        | AnnNewTab {tab, doc} => AnnNewTab {tab = tab, doc = updateVars doc}
         | _ => doc
     in
       updateVars doc
@@ -436,14 +440,13 @@ struct
   fun insertComments debug (doc: anndoc) =
     let
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
       fun isLast tok =
         not (Option.isSome (Token.nextTokenNotCommentOrWhitespace tok))
 
       fun commentsToDocs cs =
-        Seq.map (fn c => AnnToken {at=NONE, tok=c}) cs
+        Seq.map (fn c => AnnToken {at = NONE, tok = c}) cs
 
       val noComments = Seq.empty ()
 
@@ -458,11 +461,9 @@ struct
         let
           val n = Seq.length comments
           fun loop i =
-            if i >= n then n else
-            if Token.lineDifference (tok1, Seq.nth comments i) > 0 then
-              i
-            else
-              loop (i+1)
+            if i >= n then n
+            else if Token.lineDifference (tok1, Seq.nth comments i) > 0 then i
+            else loop (i + 1)
         in
           loop 0
         end
@@ -494,7 +495,8 @@ struct
        *   if not ctxAllowsComments
        *   then (commentsBefore and commentsAfter are both empty)
        *)
-      fun loop ctxAllowsComments vars doc : (bool * anndoc Seq.t * anndoc * anndoc Seq.t) =
+      fun loop ctxAllowsComments vars doc :
+        (bool * anndoc Seq.t * anndoc * anndoc Seq.t) =
         case doc of
           AnnEmpty => (false, noComments, doc, noComments)
         | AnnNewline => (false, noComments, doc, noComments)
@@ -504,18 +506,17 @@ struct
 
         | AnnAt {tab, doc} =>
             let
-              val (ht, cb, doc, ca) =
-                (* loop false vars doc *)
+              val (ht, cb, doc, ca) = (* loop false vars doc *)
                 loop (ctxAllowsComments orelse Tab.allowsComments tab) vars doc
               val numComments = Seq.length cb + Seq.length ca
               val (ht, cb, doc, ca) =
                 if numComments = 0 orelse not (Tab.allowsComments tab) then
-                  (ht, cb, AnnAt {tab=tab, doc=doc}, ca)
+                  (ht, cb, AnnAt {tab = tab, doc = doc}, ca)
                 else
                   let
                     val all =
-                      Seq.map (fn d => AnnAt {tab=tab, doc=d})
-                        (Seq.append3 (cb, Seq.singleton doc, ca))
+                      Seq.map (fn d => AnnAt {tab = tab, doc = d}) (Seq.append3
+                        (cb, Seq.singleton doc, ca))
                   in
                     (true, noComments, concatDocs all, noComments)
                   end
@@ -539,21 +540,14 @@ struct
                 if ht1 andalso ht2 then
                   ( true
                   , cb1
-                  , annConcat (d1, annConcat (concatDocs (Seq.append (ca1, cb2)), d2))
+                  , annConcat (d1, annConcat
+                      (concatDocs (Seq.append (ca1, cb2)), d2))
                   , ca2
                   )
                 else if ht1 andalso not ht2 then
-                  ( true
-                  , cb1
-                  , AnnConcat (d1, d2)
-                  , Seq.append3 (ca1, cb2, ca2)
-                  )
+                  (true, cb1, AnnConcat (d1, d2), Seq.append3 (ca1, cb2, ca2))
                 else if (not ht1) andalso ht2 then
-                  ( true
-                  , Seq.append3 (cb1, ca1, cb2)
-                  , AnnConcat (d1, d2)
-                  , ca2
-                  )
+                  (true, Seq.append3 (cb1, ca1, cb2), AnnConcat (d1, d2), ca2)
                 else
                   ( false
                   , Seq.flatten (Seq.fromList [cb1, ca1, cb2, ca2])
@@ -563,10 +557,8 @@ struct
               end
 
         | AnnNewTab {tab, doc} =>
-            let
-              val (ht, cb, doc, ca) = loop ctxAllowsComments vars doc
-            in
-              (ht, cb, AnnNewTab {tab = tab, doc = doc}, ca)
+            let val (ht, cb, doc, ca) = loop ctxAllowsComments vars doc
+            in (ht, cb, AnnNewTab {tab = tab, doc = doc}, ca)
             end
 
         | AnnCond {tab, inactive, active} =>
@@ -590,8 +582,7 @@ struct
               (ht, cb, AnnLetDoc {var = var, doc = doc, inn = inn}, ca)
             end
 
-        | AnnVar v =>
-            (VarDict.lookup vars v, noComments, doc, noComments)
+        | AnnVar v => (VarDict.lookup vars v, noComments, doc, noComments)
 
         | AnnToken {at = flow, tok} =>
             let
@@ -602,45 +593,42 @@ struct
               val doc = annConcat (doc, concatDocs ca)
             in
               if ctxAllowsComments then
-                (* (true, cb, doc, ca) *)
-                (true, cb, doc, noComments)
+                (* (true, cb, doc, ca) *) (true, cb, doc, noComments)
               else if numComments = 0 then
                 (true, noComments, doc, noComments)
               else
 
-              case flow of
-                NONE =>
-                  ( true
-                  , noComments
-                  (* , concatDocs (Seq.append3 (cb, Seq.singleton doc, ca)) *)
-                  , concatDocs (Seq.append (cb, Seq.singleton doc))
-                  , noComments
-                  )
-
-              | SOME tabs =>
-                  let
-                    val tab =
-                      (* TODO: what to do when there are multiple possible tabs
-                       * this token could be at? Here we just pick the first
-                       * of these in the set, and usually it seems each token
-                       * is only ever 'at' one possible tab...
-                       *)
-                      List.hd (TabSet.listKeys tabs)
-
-                    fun withBreak d =
-                      AnnAt {tab=tab, doc=d}
-
-                    (* val all = Seq.append3 (cb, Seq.singleton doc, ca) *)
-                    val all = Seq.append (cb, Seq.singleton doc)
-                  in
+                case flow of
+                  NONE =>
                     ( true
                     , noComments
-                    , Seq.iterate annConcat
-                        (Seq.nth all 0)
-                        (Seq.map withBreak (Seq.drop all 1))
+                    (* , concatDocs (Seq.append3 (cb, Seq.singleton doc, ca)) *)
+                    , concatDocs (Seq.append (cb, Seq.singleton doc))
                     , noComments
                     )
-                  end
+
+                | SOME tabs =>
+                    let
+                      val tab =
+                        (* TODO: what to do when there are multiple possible tabs
+                         * this token could be at? Here we just pick the first
+                         * of these in the set, and usually it seems each token
+                         * is only ever 'at' one possible tab...
+                         *) List.hd (TabSet.listKeys tabs)
+
+                      fun withBreak d =
+                        AnnAt {tab = tab, doc = d}
+
+                      (* val all = Seq.append3 (cb, Seq.singleton doc, ca) *)
+                      val all = Seq.append (cb, Seq.singleton doc)
+                    in
+                      ( true
+                      , noComments
+                      , Seq.iterate annConcat (Seq.nth all 0)
+                          (Seq.map withBreak (Seq.drop all 1))
+                      , noComments
+                      )
+                    end
             end
 
       val (_, _, doc, _) = loop false VarDict.empty doc
@@ -677,29 +665,26 @@ struct
   fun insertBlankLines debug (doc: anndoc) =
     let
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
       fun breaksBefore doc tab n =
-        if n = 0 then doc else
-        let
-          val doc =
-            AnnConcat
+        if n = 0 then
+          doc
+        else
+          let
+            val doc = AnnConcat
               ( AnnCond {tab = tab, inactive = AnnEmpty, active = AnnNewline}
               , doc
               )
-        in
-          breaksBefore doc tab (n-1)
-        end
+          in
+            breaksBefore doc tab (n - 1)
+          end
 
       fun prevTokenNotWhitespace t =
         case Token.prevToken t of
           NONE => NONE
         | SOME p =>
-            if Token.isWhitespace p then
-              prevTokenNotWhitespace p
-            else
-              SOME p
+            if Token.isWhitespace p then prevTokenNotWhitespace p else SOME p
 
       fun loop doc =
         case doc of
@@ -708,32 +693,31 @@ struct
         | AnnNoSpace => doc
         | AnnSpace => doc
         | AnnText _ => doc
-        | AnnAt {tab, doc} =>
-            AnnAt {tab=tab, doc = loop doc}
+        | AnnAt {tab, doc} => AnnAt {tab = tab, doc = loop doc}
         | AnnToken {at = NONE, tok} => doc
         | AnnToken {at = SOME tabs, tok} =>
             (case prevTokenNotWhitespace tok of
-              NONE => doc
-            | SOME prevTok =>
-                let
-                  val diff = Token.lineDifference (prevTok, tok) - 1
-                  val diff = Int.max (0, Int.min (2, diff))
-                  val _ = dbgprintln ("line diff ('" ^ Token.toString prevTok ^ "','" ^ Token.toString tok ^ "'): " ^ Int.toString diff)
-                in
-                  if diff = 0 then
-                    doc
-                  else
-                    (* TODO: what to do when there are multiple possible tabs
-                     * this token could be at? Here we just pick the first
-                     * of these in the set, and usually it seems each token
-                     * is only ever 'at' one possible tab...
-                     *)
-                    breaksBefore doc (List.hd (TabSet.listKeys tabs)) diff
-                end)
-        | AnnConcat (d1, d2) =>
-            AnnConcat (loop d1, loop d2)
-        | AnnNewTab {tab, doc} =>
-            AnnNewTab {tab = tab, doc = loop doc}
+               NONE => doc
+             | SOME prevTok =>
+                 let
+                   val diff = Token.lineDifference (prevTok, tok) - 1
+                   val diff = Int.max (0, Int.min (2, diff))
+                   val _ = dbgprintln
+                     ("line diff ('" ^ Token.toString prevTok ^ "','"
+                      ^ Token.toString tok ^ "'): " ^ Int.toString diff)
+                 in
+                   if diff = 0 then
+                     doc
+                   else
+                     (* TODO: what to do when there are multiple possible tabs
+                      * this token could be at? Here we just pick the first
+                      * of these in the set, and usually it seems each token
+                      * is only ever 'at' one possible tab...
+                      *)
+                     breaksBefore doc (List.hd (TabSet.listKeys tabs)) diff
+                 end)
+        | AnnConcat (d1, d2) => AnnConcat (loop d1, loop d2)
+        | AnnNewTab {tab, doc} => AnnNewTab {tab = tab, doc = loop doc}
         | AnnCond {tab, inactive, active} =>
             AnnCond {tab = tab, inactive = loop inactive, active = loop active}
         | AnnLetDoc {var, doc, inn} =>
@@ -753,72 +737,69 @@ struct
     if not (Token.isComment tok orelse Token.isStringConstant tok) then
       D.text (SyntaxHighlighter.highlightToken tok)
     else
-    let
-      val src = Token.getSource tok
+      let
+        val src = Token.getSource tok
 
-      (** effective offset of the beginning of this token within its line,
-        * counting tab-widths appropriately.
-        *)
-      val effectiveOffset =
-        let
-          val {col, line=lineNum} = Source.absoluteStart src
-          val len = col-1
-          val charsBeforeOnSameLine =
-            Source.take (Source.wholeLine src lineNum) len
-          fun loop effOff i =
-            if i >= len then effOff
-            else if #"\t" = Source.nth charsBeforeOnSameLine i then
-              (* advance up to next tabstop *)
-              loop (effOff + tabWidth - effOff mod tabWidth) (i+1)
-            else
-              loop (effOff+1) (i+1)
-        in
-          loop 0 0
-        end
+        (** effective offset of the beginning of this token within its line,
+          * counting tab-widths appropriately.
+          *)
+        val effectiveOffset =
+          let
+            val {col, line = lineNum} = Source.absoluteStart src
+            val len = col - 1
+            val charsBeforeOnSameLine =
+              Source.take (Source.wholeLine src lineNum) len
+            fun loop effOff i =
+              if i >= len then
+                effOff
+              else if #"\t" = Source.nth charsBeforeOnSameLine i then
+                (* advance up to next tabstop *)
+                loop (effOff + tabWidth - effOff mod tabWidth) (i + 1)
+              else
+                loop (effOff + 1) (i + 1)
+          in
+            loop 0 0
+          end
 
-      fun strip line =
-        let
-          val (_, ln) =
-            TCS.stripEffectiveWhitespace
-              {tabWidth=tabWidth, removeAtMost=effectiveOffset}
-              line
-        in
-          ln
-        end
+        fun strip line =
+          let
+            val (_, ln) =
+              TCS.stripEffectiveWhitespace
+                {tabWidth = tabWidth, removeAtMost = effectiveOffset} line
+          in
+            ln
+          end
 
-      val t = SyntaxHighlighter.highlightToken tok
+        val t = SyntaxHighlighter.highlightToken tok
 
-      val pieces =
-        Seq.map
-          (fn (i, j) => D.text (strip (TCS.substring (t, i, j-i))))
-          (Source.lineRanges src)
+        val pieces =
+          Seq.map (fn (i, j) => D.text (strip (TCS.substring (t, i, j - i))))
+            (Source.lineRanges src)
 
-      val numPieces = Seq.length pieces
-    in
-      if numPieces = 1 then
-        D.text t
-      else
-        let
-          val tab = Tab.new
-            { parent = currentTab
-            , style = Tab.Style.combine (Tab.Style.inplace, Tab.Style.rigid)
-            }
-          val doc =
-            (* a bit of a hack here: we concatenate a space on the end of
-             * each piece (except last), which guarantees that blank lines
-             * within the comment are preserved.
-             *)
-            Seq.iterate D.concat D.empty
-              (Seq.map (fn x => D.at tab (D.concat (x, D.space)))
-                (Seq.take pieces (numPieces-1)))
-          val doc =
-            D.concat (doc, D.at tab (Seq.nth pieces (numPieces-1)))
-          val doc =
-            D.newTab (tab, doc)
-        in
-          doc
-        end
-    end
+        val numPieces = Seq.length pieces
+      in
+        if numPieces = 1 then
+          D.text t
+        else
+          let
+            val tab = Tab.new
+              { parent = currentTab
+              , style = Tab.Style.combine (Tab.Style.inplace, Tab.Style.rigid)
+              }
+            val doc =
+              (* a bit of a hack here: we concatenate a space on the end of
+               * each piece (except last), which guarantees that blank lines
+               * within the comment are preserved.
+               *)
+              Seq.iterate D.concat D.empty
+                (Seq.map (fn x => D.at tab (D.concat (x, D.space)))
+                   (Seq.take pieces (numPieces - 1)))
+            val doc = D.concat (doc, D.at tab (Seq.nth pieces (numPieces - 1)))
+            val doc = D.newTab (tab, doc)
+          in
+            doc
+          end
+      end
 
   (* ====================================================================== *)
 
@@ -832,8 +813,7 @@ struct
   fun toStringDoc (args as {tabWidth, debug}) doc =
     let
       fun dbgprintln s =
-        if not debug then ()
-        else print (s ^ "\n")
+        if not debug then () else print (s ^ "\n")
 
       val (doc, tm) = Util.getTime (fn _ => annotate doc)
       val _ = dbgprintln ("annotate: " ^ Time.fmt 3 tm ^ "s")
@@ -858,26 +838,25 @@ struct
         | AnnToken {at, tok} =>
             let
               val tab =
-                case at of
+                case
+                  at
+                of
                   NONE => currentTab
                 | SOME tabs =>
                     (* TODO: what to do when there are multiple possible
-                     * tabs here? *)
-                    List.hd (TabSet.listKeys tabs)
+                     * tabs here? *) List.hd (TabSet.listKeys tabs)
 
               val doc = tokenToStringDoc tab tabWidth tok
             in
               doc
             end
-        | AnnAt {tab, doc, ...} =>
-            D.at tab (loop currentTab vars doc)
+        | AnnAt {tab, doc, ...} => D.at tab (loop currentTab vars doc)
         | AnnCond {tab, inactive, active} =>
             D.cond tab
               { inactive = loop currentTab vars inactive
               , active = loop currentTab vars active
               }
-        | AnnNewTab {tab, doc} =>
-            D.newTab (tab, loop tab vars doc)
+        | AnnNewTab {tab, doc} => D.newTab (tab, loop tab vars doc)
         | AnnLetDoc {var, doc, inn} =>
             let
               val doc' = loop currentTab vars doc
@@ -885,11 +864,9 @@ struct
             in
               loop currentTab vars inn
             end
-        | AnnVar v =>
-            VarDict.lookup vars v
+        | AnnVar v => VarDict.lookup vars v
 
-      val (result, tm) = Util.getTime (fn _ =>
-        loop Tab.root VarDict.empty doc)
+      val (result, tm) = Util.getTime (fn _ => loop Tab.root VarDict.empty doc)
 
       val _ = dbgprintln ("convert: " ^ Time.fmt 3 tm ^ "s")
     in

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -15,8 +15,10 @@ struct
 
   infix 2 ++ $$ // +/+ +$+
   infix 1 \\
-  fun x +/+ y = besideAndAbove (x, y)
-  fun x +$+ y = besideAndAboveOrSpace (x, y)
+  fun x +/+ y =
+    besideAndAbove (x, y)
+  fun x +$+ y =
+    besideAndAboveOrSpace (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat
@@ -29,55 +31,43 @@ struct
           , maybeShowSyntaxSeq tyvars token
           , SOME (token tycon)
           , SOME (token eq)
-          ]
-        \\
-        showTy ty
+          ] \\ showTy ty
     in
-      rigidVertically
-        (showOne (front, Seq.nth elems 0))
-        (Seq.zipWith showOne (delims, Seq.drop elems 1))
+      rigidVertically (showOne (front, Seq.nth elems 0)) (Seq.zipWith showOne
+        (delims, Seq.drop elems 1))
     end
 
 
   fun showDatbind (front, datbind: Ast.Exp.datbind as {elems, delims}) =
     let
       fun showCon (starter, {opp, id, arg}) =
-        starter
-        ++ space ++
-        group (
-          separateWithSpaces
-            [ Option.map token opp
-            , SOME (token id)
-            , Option.map (fn {off, ty} => token off \\ showTy ty) arg
-            ]
-        )
+        starter ++ space
+        ++
+        group (separateWithSpaces
+          [ Option.map token opp
+          , SOME (token id)
+          , Option.map (fn {off, ty} => token off \\ showTy ty) arg
+          ])
 
       fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
         let
-          val initial =
-            group (
-              separateWithSpaces
-                [ SOME (token starter)
-                , maybeShowSyntaxSeq tyvars token
-                , SOME (token tycon)
-                , SOME (token eq)
-                ]
-            )
+          val initial = group (separateWithSpaces
+            [ SOME (token starter)
+            , maybeShowSyntaxSeq tyvars token
+            , SOME (token tycon)
+            , SOME (token eq)
+            ])
         in
-          group (
-            initial
-            $$
-            group (
-              Seq.iterate op$$
-                (showCon (space, Seq.nth elems 0))
-                (Seq.zipWith showCon (Seq.map token delims, Seq.drop elems 1))
-            )
-          )
+          group
+            (initial
+             $$
+             group
+               (Seq.iterate op$$ (showCon (space, Seq.nth elems 0))
+                  (Seq.zipWith showCon (Seq.map token delims, Seq.drop elems 1))))
         end
     in
-      rigidVertically
-        (showOne (front, Seq.nth elems 0))
-        (Seq.zipWith showOne (delims, Seq.drop elems 1))
+      rigidVertically (showOne (front, Seq.nth elems 0)) (Seq.zipWith showOne
+        (delims, Seq.drop elems 1))
     end
 
 
@@ -96,33 +86,26 @@ struct
     end
 
 
-  fun showDecFun {funn, tyvars, fvalbind={elems, delims}} =
+  fun showDecFun {funn, tyvars, fvalbind = {elems, delims}} =
     let
       open Ast.Exp
 
       fun showArgs args =
-        if Seq.length args = 0 then empty else
-        Seq.iterate (fn (prev, p) => prev ++ space ++ showPat p)
-          (showPat (Seq.nth args 0))
-          (Seq.drop args 1)
+        if Seq.length args = 0 then
+          empty
+        else
+          Seq.iterate (fn (prev, p) => prev ++ space ++ showPat p)
+            (showPat (Seq.nth args 0)) (Seq.drop args 1)
 
       fun showInfixed larg id rarg =
-        showPat larg
-        ++ space
-        ++ token id
-        ++ space
-        ++ showPat rarg
+        showPat larg ++ space ++ token id ++ space ++ showPat rarg
 
       fun showFNameArgs xx =
         case xx of
           PrefixedFun {opp, id, args} =>
             separateWithSpaces
-              [ Option.map token opp
-              , SOME (token id)
-              , SOME (showArgs args)
-              ]
-        | InfixedFun {larg, id, rarg} =>
-            showInfixed larg id rarg
+              [Option.map token opp, SOME (token id), SOME (showArgs args)]
+        | InfixedFun {larg, id, rarg} => showInfixed larg id rarg
         | CurriedInfixedFun {lparen, larg, id, rarg, rparen, args} =>
             separateWithSpaces
               [ SOME (token lparen ++ showInfixed larg id rarg ++ token rparen)
@@ -133,19 +116,17 @@ struct
         token colon ++ space ++ showTy ty
 
       fun showClause (align, indentExp) (front, {fname_args, ty, eq, exp}) =
-        align ++
-        group (
-          separateWithSpaces
-            [ SOME front
-            , SOME (showFNameArgs fname_args)
-            , Option.map showColonTy ty
-            , SOME (token eq)
-            ]
-          $$
-          indentExp (showExp exp)
-        )
+        align
+        ++
+        group
+          (separateWithSpaces
+             [ SOME front
+             , SOME (showFNameArgs fname_args)
+             , Option.map showColonTy ty
+             , SOME (token eq)
+             ] $$ indentExp (showExp exp))
 
-      fun mkFunction (starter, {elems=innerElems, delims}) =
+      fun mkFunction (starter, {elems = innerElems, delims}) =
         let
           fun firstIndentExp x =
             spaces (if Seq.length innerElems = 1 then 0 else 4) ++ indent x
@@ -157,14 +138,13 @@ struct
           rigidVertically
             (showClause firstParams (starter, Seq.nth innerElems 0))
             (Seq.zipWith (showClause restParams)
-              (Seq.map token delims, Seq.drop innerElems 1))
+               (Seq.map token delims, Seq.drop innerElems 1))
         end
 
-      val front =
-        separateWithSpaces [SOME (token funn), maybeShowSyntaxSeq tyvars token]
+      val front = separateWithSpaces
+        [SOME (token funn), maybeShowSyntaxSeq tyvars token]
     in
-      rigidVertically
-        (mkFunction (front, Seq.nth elems 0))
+      rigidVertically (mkFunction (front, Seq.nth elems 0))
         (Seq.zipWith mkFunction (Seq.map token delims, Seq.drop elems 1))
     end
 
@@ -182,8 +162,7 @@ struct
                 , Option.map token recc
                 , SOME (showPat pat)
                 , SOME (token eq)
-                ]
-              \\ showExp exp
+                ] \\ showExp exp
 
             val first =
               let
@@ -195,21 +174,16 @@ struct
                   , Option.map token recc
                   , SOME (showPat pat)
                   , SOME (token eq)
-                  ]
-                \\
-                showExp exp
+                  ] \\ showExp exp
               end
           in
-            rigidVertically
-              first
-              (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
+            rigidVertically first (Seq.map mk (Seq.zip
+              (delims, Seq.drop elems 1)))
           end
 
-      | DecFun args =>
-          showDecFun args
+      | DecFun args => showDecFun args
 
-      | DecType {typee, typbind} =>
-          showTypbind (typee, typbind)
+      | DecType {typee, typbind} => showTypbind (typee, typbind)
 
       | DecDatatype {datatypee, datbind, withtypee} =>
           let
@@ -247,8 +221,8 @@ struct
                   separateWithSpaces
                     [ Option.map token opp
                     , SOME (token id)
-                    , Option.map (fn {off, ty} =>
-                        token off ++ space ++ showTy ty) arg
+                    , Option.map
+                        (fn {off, ty} => token off ++ space ++ showTy ty) arg
                     ]
 
               | ExnReplicate {opp, left_id, eq, right_id} =>
@@ -262,23 +236,14 @@ struct
             fun showOne (starter, elem) =
               token starter ++ space ++ showExbind elem
           in
-            rigidVertically
-              (showOne (exceptionn, Seq.nth elems 0))
+            rigidVertically (showOne (exceptionn, Seq.nth elems 0))
               (Seq.zipWith showOne (delims, Seq.drop elems 1))
           end
 
       | DecLocal {locall, left_dec, inn, right_dec, endd} =>
-          rigid (
-            token locall
-            $$
-            indent (showDec left_dec)
-            $$
-            token inn
-            $$
-            indent (showDec right_dec)
-            $$
-            token endd
-          )
+          rigid
+            (token locall $$ indent (showDec left_dec) $$ token inn
+             $$ indent (showDec right_dec) $$ token endd)
 
       | DecMultiple {elems, delims} =>
           let
@@ -286,14 +251,14 @@ struct
               showDec (Seq.nth elems i)
               ++
               (case Seq.nth delims i of
-                NONE => empty
-              | SOME semicolon => token semicolon)
+                 NONE => empty
+               | SOME semicolon => token semicolon)
           in
-            rigid (Util.loop (0, Seq.length elems) empty (fn (prev, i) => prev $$ f i))
+            rigid (Util.loop (0, Seq.length elems) empty (fn (prev, i) =>
+              prev $$ f i))
           end
 
-      | DecEmpty =>
-          empty
+      | DecEmpty => empty
 
       | DecOpen {openn, elems} =>
           token openn ++ space
@@ -301,42 +266,29 @@ struct
 
       | DecAbstype {abstypee, datbind, withtypee, withh, dec, endd} =>
           let
-            val datbinds =
-              showDatbind (abstypee, datbind)
+            val datbinds = showDatbind (abstypee, datbind)
 
-            val bottom =
-              group (
-                token withh
-                $$
-                indent (showDec dec)
-                $$
-                token endd
-              )
+            val bottom = group
+              (token withh $$ indent (showDec dec) $$ token endd)
           in
-            group (
-              case withtypee of
-                SOME {withtypee, typbind} =>
-                  datbinds
-                  $$
-                  showTypbind (withtypee, typbind)
-                  $$
-                  bottom
+            group
+              (case withtypee of
+                 SOME {withtypee, typbind} =>
+                   datbinds $$ showTypbind (withtypee, typbind) $$ bottom
 
-              | _ => datbinds $$ bottom
-            )
+               | _ => datbinds $$ bottom)
           end
 
       | DecReplicateDatatype
-        {left_datatypee, left_id, eq, right_datatypee, right_id} =>
+          {left_datatypee, left_id, eq, right_datatypee, right_id} =>
           seqWithSpaces
             (Seq.fromList
-              [ left_datatypee
-              , left_id
-              , eq
-              , right_datatypee
-              , MaybeLongToken.getToken right_id
-              ])
-            token
+               [ left_datatypee
+               , left_id
+               , eq
+               , right_datatypee
+               , MaybeLongToken.getToken right_id
+               ]) token
     end
 
 
@@ -345,17 +297,12 @@ struct
       open Ast.Exp
     in
       case exp of
-        Const tok =>
-          token tok
-      | Unit {left, right} =>
-          token left ++ token right
+        Const tok => token tok
+      | Unit {left, right} => token left ++ token right
       | Ident {opp, id} =>
           separateWithSpaces
-            [ Option.map token opp
-            , SOME (token (MaybeLongToken.getToken id))
-            ]
-      | Parens {left, exp, right} =>
-          token left ++ showExp exp ++ token right
+            [Option.map token opp, SOME (token (MaybeLongToken.getToken id))]
+      | Parens {left, exp, right} => token left ++ showExp exp ++ token right
       | Tuple {left, elems, delims, right} =>
           sequence left delims right (Seq.map showExp elems)
       | Sequence {left, elems, delims, right} =>
@@ -365,21 +312,16 @@ struct
       | Record {left, elems, delims, right} =>
           let
             fun showRow {lab, eq, exp} =
-              (token lab ++ space ++ token eq)
-              \\ showExp exp
+              (token lab ++ space ++ token eq) \\ showExp exp
           in
             sequence left delims right (Seq.map showRow elems)
           end
-      | Select {hash, label} =>
-          token hash ++ space ++ token label
-      | App {left, right} =>
-          showExp left \\ showExp right
-      | Infix {left, id, right} =>
-          showInfixedExp (left, id, right)
+      | Select {hash, label} => token hash ++ space ++ token label
+      | App {left, right} => showExp left \\ showExp right
+      | Infix {left, id, right} => showInfixedExp (left, id, right)
       | Andalso {left, andalsoo, right} =>
           showInfixedExp (left, andalsoo, right)
-      | Orelse {left, orelsee, right} =>
-          showInfixedExp (left, orelsee, right)
+      | Orelse {left, orelsee, right} => showInfixedExp (left, orelsee, right)
       | Typed {exp, colon, ty} =>
           showExp exp ++ space ++ token colon ++ space ++ showTy ty
       | IfThenElse {iff, exp1, thenn, exp2, elsee, exp3} =>
@@ -389,89 +331,61 @@ struct
                 IfThenElse _ => besideAndAboveOrSpace
               | _ => aboveOrSpace
           in
-            group (
-              token iff
-              $$
-              indent (showExp exp1)
-              $$
-              token thenn
-            )
-            $$
-            indent (showExp exp2)
-            $$
-            combinator (token elsee, indent (showExp exp3))
+            group (token iff $$ indent (showExp exp1) $$ token thenn)
+            $$ indent (showExp exp2)
+            $$ combinator (token elsee, indent (showExp exp3))
           end
       | While {whilee, exp1, doo, exp2} =>
-          group (
-            group (
-              token whilee
-              $$
-              indent (showExp exp1)
-              $$
-              token doo
-            )
-            $$
-            indent (showExp exp2)
-          )
+          group
+            (group (token whilee $$ indent (showExp exp1) $$ token doo)
+             $$ indent (showExp exp2))
 
-      | Raise {raisee, exp} =>
-          token raisee \\ showExp exp
+      | Raise {raisee, exp} => token raisee \\ showExp exp
 
-      | Handle {exp=expLeft, handlee, elems, delims} =>
+      | Handle {exp = expLeft, handlee, elems, delims} =>
           let
             fun showBranch {pat, arrow, exp} =
-              showPat pat ++ space ++ token arrow
-              \\ showExp exp
-            fun mk (delim, branch) = token delim ++ space ++ showBranch branch
+              showPat pat ++ space ++ token arrow \\ showExp exp
+            fun mk (delim, branch) =
+              token delim ++ space ++ showBranch branch
           in
             showExp expLeft
             \\
-            (
-              token handlee
-              \\
-              rigidVertically
-                (indent (showBranch (Seq.nth elems 0)))
-                (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
-            )
+            (token handlee
+             \\
+             rigidVertically (indent (showBranch (Seq.nth elems 0)))
+               (Seq.map mk (Seq.zip (delims, Seq.drop elems 1))))
           end
 
-      | Case {casee, exp=expTop, off, elems, delims} =>
+      | Case {casee, exp = expTop, off, elems, delims} =>
           let
             fun showBranch {pat, arrow, exp} =
-              showPat pat ++ space ++ token arrow
-              \\ showExp exp
-            fun mk (delim, branch) = token delim ++ space ++ showBranch branch
+              showPat pat ++ space ++ token arrow \\ showExp exp
+            fun mk (delim, branch) =
+              token delim ++ space ++ showBranch branch
           in
-            rigid (
-              token casee ++ space ++ showExp expTop ++ space ++ token off
-              $$
-              rigidVertically
-                (indent (showBranch (Seq.nth elems 0)))
-                (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
-            )
+            rigid
+              (token casee ++ space ++ showExp expTop ++ space ++ token off
+               $$
+               rigidVertically (indent (showBranch (Seq.nth elems 0)))
+                 (Seq.map mk (Seq.zip (delims, Seq.drop elems 1))))
           end
 
       | Fn {fnn, elems, delims} =>
           let
             fun mk (delim, {pat, arrow, exp}) =
-              space ++
-              (
-                (token delim ++ space ++ showPat pat ++ space ++ token arrow)
-                \\
-                showExp exp
-              )
+              space
+              ++
+              ((token delim ++ space ++ showPat pat ++ space ++ token arrow)
+               \\ showExp exp)
 
             val {pat, arrow, exp} = Seq.nth elems 0
             val initial =
               (token fnn ++ space ++ showPat pat ++ space ++ token arrow)
-              \\
-              showExp exp
+              \\ showExp exp
           in
-            group (
-              Seq.iterate op$$
-                initial
-                (Seq.map mk (Seq.zip (delims, Seq.drop elems 1)))
-            )
+            group (Seq.iterate op$$ initial (Seq.map mk (Seq.zip
+              (delims, Seq.drop elems 1))))
           end
 
       | LetInEnd {lett, dec, inn, exps, delims, endd} =>
@@ -481,38 +395,28 @@ struct
 
             fun d i = Seq.nth delims i
 
-            val withDelims = Seq.mapIdx (fn (i, e) =>
-                showExp e ++ (if i = numExps - 1 then empty else token (d i)))
-              exps
+            val withDelims =
+              Seq.mapIdx
+                (fn (i, e) =>
+                   showExp e ++ (if i = numExps - 1 then empty else token (d i)))
+                exps
+
+            val topPart = token lett $$ indent (prettyDec) $$ token inn
 
             val topPart =
-              token lett
-              $$
-              indent (prettyDec)
-              $$
-              token inn
-
-            val topPart =
-              if Ast.Exp.isMultipleDecs dec then
-                topPart
-              else
-                group topPart
+              if Ast.Exp.isMultipleDecs dec then topPart else group topPart
           in
-            group (
-              topPart
-              $$
-              indent (group (Seq.iterate op$$ empty withDelims))
-              $$
-              token endd
-            )
+            group
+              (topPart $$ indent (group (Seq.iterate op$$ empty withDelims))
+               $$ token endd)
           end
 
       | MLtonSpecific {underscore, directive, contents, semicolon} =>
-          token underscore ++ token directive
-          ++ space ++ seqWithSpaces contents token ++ token semicolon
+          token underscore ++ token directive ++ space
+          ++ seqWithSpaces contents token ++ token semicolon
     end
 
-  
+
   (* TODO: This is still not quite right *)
   and showInfixedExp (l, t, r) =
     let
@@ -525,15 +429,9 @@ struct
             if not (Token.same (t, lt)) then
               NONE
             else
-              SOME (group (
-                group (
-                  showInfixedExp (ll, lt, lr)
-                  $$ token t
-                )
-                +$+
-                showExp r
-              ))
-      
+              SOME (group
+                (group (showInfixedExp (ll, lt, lr) $$ token t) +$+ showExp r))
+
       fun tryRight () =
         case tryViewAsInfix r of
           NONE => NONE
@@ -541,15 +439,8 @@ struct
             if not (Token.same (t, rt)) then
               NONE
             else
-              SOME (group (
-                group (
-                  showExp l
-                  $$
-                  token t
-                )
-                +$+
-                showInfixedExp (rl, rt, rr)
-              ))
+              SOME (group
+                (group (showExp l $$ token t) +$+ showInfixedExp (rl, rt, rr)))
 
       fun normal () =
         group (group (showExp l $$ token t) +$+ showExp r)
@@ -558,11 +449,9 @@ struct
         SOME x => x
       | NONE =>
 
-      case tryRight () of
-        SOME x => x
-      | NONE =>
-
-      normal ()
+          case tryRight () of
+            SOME x => x
+          | NONE => normal ()
     end
 
 end

--- a/src/pretty-print/PrettyFun.sml
+++ b/src/pretty-print/PrettyFun.sml
@@ -29,35 +29,26 @@ struct
     case fa of
       Ast.Fun.ArgSpec spec => showSpec spec
     | Ast.Fun.ArgIdent {strid, colon, sigexp} =>
-        group (
-          token strid
-          ++ space ++ token colon ++ space ++
-          showSigExp sigexp
-        )
+        group
+          (token strid ++ space ++ token colon ++ space ++ showSigExp sigexp)
 
   fun showFunDec (Ast.Fun.DecFunctor {functorr, elems, delims}) =
     let
       fun showFunctor
-        (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp})
-        =
+        (starter, {funid, lparen, funarg, rparen, constraint, eq, strexp}) =
+        separateWithSpaces [SOME (token starter), SOME (token funid)]
+        \\
         separateWithSpaces
-          [ SOME (token starter)
-          , SOME (token funid)
+          [ SOME (token lparen ++ showFunArg funarg ++ token rparen)
+          , Option.map (fn {colon, ...} => token colon) constraint
           ]
-        \\ separateWithSpaces
-             [ SOME (token lparen ++ showFunArg funarg ++ token rparen)
-             , Option.map
-                 (fn {colon, ...} => token colon)
-                 constraint
-             ]
-        \\ separateWithSpaces
-              [ Option.map (fn {sigexp, ...} => showSigExp sigexp) constraint
-              , SOME (token eq)
-              ]
-        \\ showStrExp strexp
+        \\
+        separateWithSpaces
+          [ Option.map (fn {sigexp, ...} => showSigExp sigexp) constraint
+          , SOME (token eq)
+          ] \\ showStrExp strexp
     in
-      rigidVertically
-        (showFunctor (functorr, Seq.nth elems 0))
+      rigidVertically (showFunctor (functorr, Seq.nth elems 0))
         (Seq.map showFunctor (Seq.zip (delims, Seq.drop elems 1)))
     end
 

--- a/src/pretty-print/PrettyPat.sml
+++ b/src/pretty-print/PrettyPat.sml
@@ -13,9 +13,12 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ //
-  fun x ++ y = beside (x, y)
-  fun x $$ y = aboveOrSpace (x, y)
-  fun x // y = aboveOrBeside (x, y)
+  fun x ++ y =
+    beside (x, y)
+  fun x $$ y =
+    aboveOrSpace (x, y)
+  fun x // y =
+    aboveOrBeside (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
 
@@ -24,19 +27,13 @@ struct
       open Ast.Pat
     in
       case pat of
-        Wild tok =>
-          token tok
-      | Const tok =>
-          token tok
-      | Unit {left, right} =>
-          token left ++ token right
+        Wild tok => token tok
+      | Const tok => token tok
+      | Unit {left, right} => token left ++ token right
       | Ident {opp, id} =>
           separateWithSpaces
-            [ Option.map token opp
-            , SOME (token (MaybeLongToken.getToken id))
-            ]
-      | Parens {left, pat, right} =>
-          token left ++ showPat pat ++ token right
+            [Option.map token opp, SOME (token (MaybeLongToken.getToken id))]
+      | Parens {left, pat, right} => token left ++ showPat pat ++ token right
       | Tuple {left, elems, delims, right} =>
           sequence left delims right (Seq.map showPat elems)
       | List {left, elems, delims, right} =>
@@ -47,13 +44,15 @@ struct
               case patrow of
                 DotDotDot ddd => token ddd
               | LabEqPat {lab, eq, pat} =>
-                  token lab ++ space ++ token eq
-                  ++ space ++ showPat pat
+                  token lab ++ space ++ token eq ++ space ++ showPat pat
               | LabAsPat {id, ty, aspat} =>
                   separateWithSpaces
                     [ SOME (token id)
-                    , Option.map (fn {colon, ty} => token colon ++ space ++ showTy ty) ty
-                    , Option.map (fn {ass, pat} => token ass ++ space ++ showPat pat) aspat
+                    , Option.map
+                        (fn {colon, ty} => token colon ++ space ++ showTy ty) ty
+                    , Option.map
+                        (fn {ass, pat} => token ass ++ space ++ showPat pat)
+                        aspat
                     ]
           in
             sequence left delims right (Seq.map showPatRow elems)
@@ -70,7 +69,8 @@ struct
           separateWithSpaces
             [ Option.map token opp
             , SOME (token id)
-            , Option.map (fn {colon, ty} => token colon ++ space ++ showTy ty) ty
+            , Option.map (fn {colon, ty} => token colon ++ space ++ showTy ty)
+                ty
             , SOME (token ass)
             , SOME (showPat pat)
             ]

--- a/src/pretty-print/PrettyPrintAst.sml
+++ b/src/pretty-print/PrettyPrintAst.sml
@@ -5,9 +5,10 @@
 
 structure PrettyPrintAst:
 sig
-  val pretty: {ribbonFrac: real, maxWidth: int, tabWidth: int, indent: int, debug: bool}
-           -> Ast.t
-           -> TerminalColorString.t
+  val pretty:
+    {ribbonFrac: real, maxWidth: int, tabWidth: int, indent: int, debug: bool}
+    -> Ast.t
+    -> TerminalColorString.t
 end =
 struct
 
@@ -16,9 +17,12 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ //
-  fun x ++ y = beside (x, y)
-  fun x $$ y = aboveOrSpace (x, y)
-  fun x // y = aboveOrBeside (x, y)
+  fun x ++ y =
+    beside (x, y)
+  fun x $$ y =
+    aboveOrSpace (x, y)
+  fun x // y =
+    aboveOrBeside (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat
@@ -45,10 +49,11 @@ struct
               | Ast.SigDec d => showSigDec d
               | Ast.FunDec d => showFunDec d
               | Ast.TopExp _ =>
-                  raise Fail "unsupported: top-level expressions. Note: you are \
-                             \using `-engine pretty`, which is headed towards \
-                             \deprecation. Please use `-engine prettier` instead, \
-                             \which supports top-level expressions."
+                  raise Fail
+                    "unsupported: top-level expressions. Note: you are \
+                    \using `-engine pretty`, which is headed towards \
+                    \deprecation. Please use `-engine prettier` instead, \
+                    \which supports top-level expressions."
             val sc =
               case semicolon of
                 NONE => empty
@@ -70,8 +75,8 @@ struct
       val doc = TokenDoc.insertBlankLines doc
     in
       StringDoc.pretty
-        {ribbonFrac=ribbonFrac, maxWidth=maxWidth, indentWidth=indent}
-        (toStringDoc {tabWidth=tabWidth} doc)
+        {ribbonFrac = ribbonFrac, maxWidth = maxWidth, indentWidth = indent}
+        (toStringDoc {tabWidth = tabWidth} doc)
     end
 
 end

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -23,20 +23,18 @@ struct
   fun showDec dec = PrettyExpAndDec.showDec dec
 
   fun showSpec spec =
-    case spec of
-      Ast.Sig.EmptySpec =>
-        empty
+    case
+      spec
+    of
+      Ast.Sig.EmptySpec => empty
 
     | Ast.Sig.Val {vall, elems, delims} =>
         let
           fun showOne (starter, {vid, colon, ty}) =
-            token starter
-            ++ space ++
-            token vid ++ space ++ token colon ++ space
+            token starter ++ space ++ token vid ++ space ++ token colon ++ space
             ++ showTy ty
         in
-          rigidVertically
-            (showOne (vall, Seq.nth elems 0))
+          rigidVertically (showOne (vall, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
@@ -49,8 +47,7 @@ struct
               , SOME (token tycon)
               ]
         in
-          rigidVertically
-            (showOne (typee, Seq.nth elems 0))
+          rigidVertically (showOne (typee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
@@ -65,8 +62,7 @@ struct
               , SOME (showTy ty)
               ]
         in
-          rigidVertically
-            (showOne (typee, Seq.nth elems 0))
+          rigidVertically (showOne (typee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
@@ -79,8 +75,7 @@ struct
               , SOME (token tycon)
               ]
         in
-          rigidVertically
-            (showOne (eqtypee, Seq.nth elems 0))
+          rigidVertically (showOne (eqtypee, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
@@ -90,112 +85,87 @@ struct
           *)
         let
           fun showCon (starter, {vid, arg}) =
-            starter
-            ++ space ++
-            group (
-              separateWithSpaces
-                [ SOME (token vid)
-                , Option.map (fn {off, ty} =>
-                    token off $$ indent (showTy ty)) arg
-                ]
-            )
+            starter ++ space
+            ++
+            group (separateWithSpaces
+              [ SOME (token vid)
+              , Option.map (fn {off, ty} => token off $$ indent (showTy ty)) arg
+              ])
 
           fun show_datdesc (starter, {tyvars, tycon, eq, elems, delims}) =
             let
-              val initial =
-                group (
-                  separateWithSpaces
-                    [ SOME (token starter)
-                    , maybeShowSyntaxSeq tyvars token
-                    , SOME (token tycon)
-                    , SOME (token eq)
-                    ]
-                )
+              val initial = group (separateWithSpaces
+                [ SOME (token starter)
+                , maybeShowSyntaxSeq tyvars token
+                , SOME (token tycon)
+                , SOME (token eq)
+                ])
             in
-              group (
-                initial
-                $$
-                group (
-                  Seq.iterate op$$
-                    (showCon (space, Seq.nth elems 0))
-                    (Seq.zipWith showCon (Seq.map token delims, Seq.drop elems 1))
-                )
-              )
+              group
+                (initial
+                 $$
+                 group
+                   (Seq.iterate op$$ (showCon (space, Seq.nth elems 0))
+                      (Seq.zipWith showCon
+                         (Seq.map token delims, Seq.drop elems 1))))
             end
         in
-          rigidVertically
-            (show_datdesc (datatypee, Seq.nth elems 0))
+          rigidVertically (show_datdesc (datatypee, Seq.nth elems 0))
             (Seq.zipWith show_datdesc (delims, Seq.drop elems 1))
         end
 
     | Ast.Sig.ReplicateDatatype
-      {left_datatypee, left_id, eq, right_datatypee, right_id} =>
-        group (
-          separateWithSpaces
-            [ SOME (token left_datatypee)
-            , SOME (token left_id)
-            , SOME (token eq)
-            ]
-          $$
-          indent (
-            token right_datatypee
-            ++ space ++
-            token (MaybeLongToken.getToken right_id)
-          )
-        )
+        {left_datatypee, left_id, eq, right_datatypee, right_id} =>
+        group
+          (separateWithSpaces
+             [ SOME (token left_datatypee)
+             , SOME (token left_id)
+             , SOME (token eq)
+             ]
+           $$
+           indent
+             (token right_datatypee ++ space
+              ++ token (MaybeLongToken.getToken right_id)))
 
     | Ast.Sig.Exception {exceptionn, elems, delims} =>
         let
           fun showOne (starter, {vid, arg}) =
-              group (
-                separateWithSpaces
-                  [ SOME (token starter)
-                  , SOME (token vid)
-                  , Option.map (fn {off, ty} => token off ++ space ++ showTy ty) arg
-                  ]
-              )
+            group (separateWithSpaces
+              [ SOME (token starter)
+              , SOME (token vid)
+              , Option.map (fn {off, ty} => token off ++ space ++ showTy ty) arg
+              ])
         in
-          rigidVertically
-            (showOne (exceptionn, Seq.nth elems 0))
+          rigidVertically (showOne (exceptionn, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
     | Ast.Sig.Structure {structuree, elems, delims} =>
         let
           fun showOne (starter, {id, colon, sigexp}) =
-            group (
-              separateWithSpaces
-                [ SOME (token starter)
-                , SOME (token id)
-                , SOME (token colon)
-                ]
-              $$
-              indent (showSigExp sigexp)
-            )
+            group
+              (separateWithSpaces
+                 [SOME (token starter), SOME (token id), SOME (token colon)]
+               $$ indent (showSigExp sigexp))
         in
-          rigidVertically
-            (showOne (structuree, Seq.nth elems 0))
+          rigidVertically (showOne (structuree, Seq.nth elems 0))
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
     | Ast.Sig.Include {includee, sigexp} =>
-        group (
-          token includee
-          $$
-          indent (showSigExp sigexp)
-        )
+        group (token includee $$ indent (showSigExp sigexp))
 
     | Ast.Sig.IncludeIds {includee, sigids} =>
-        Seq.iterate (fn (a, b) => a ++ space ++ token b)
-          (token includee)
-          sigids
+        Seq.iterate (fn (a, b) => a ++ space ++ token b) (token includee) sigids
 
     | Ast.Sig.Multiple {elems, delims} =>
         let
           fun showOne (elem: Ast.Sig.spec, delim: Token.t option) =
             showSpec elem
             ++
-            (case delim of NONE => empty | SOME sc => token sc)
+            (case delim of
+               NONE => empty
+             | SOME sc => token sc)
         in
           rigid (Seq.iterate op$$ empty (Seq.zipWith showOne (elems, delims)))
         end
@@ -203,73 +173,54 @@ struct
     | Ast.Sig.Sharing {spec, sharingg, elems, delims} =>
         let
           fun showOne (delim, elem) =
-            token delim (** this is an '=' *)
-            ++ space
+            token delim (** this is an '=' *) ++ space
             ++ token (MaybeLongToken.getToken elem)
 
           val stuff =
-            Seq.iterate
-              (fn (a, b) => a ++ space ++ b)
+            Seq.iterate (fn (a, b) => a ++ space ++ b)
               (token (MaybeLongToken.getToken (Seq.nth elems 0)))
               (Seq.zipWith showOne (delims, Seq.drop elems 1))
         in
-          group (
-            showSpec spec
-            $$
-            rigid (token sharingg ++ space ++ stuff)
-          )
+          group (showSpec spec $$ rigid (token sharingg ++ space ++ stuff))
         end
 
     | Ast.Sig.SharingType {spec, sharingg, typee, elems, delims} =>
         let
           fun showOne (delim, elem) =
-            token delim (** this is an '=' *)
-            ++ space
+            token delim (** this is an '=' *) ++ space
             ++ token (MaybeLongToken.getToken elem)
 
           val stuff =
-            Seq.iterate
-              (fn (a, b) => a ++ space ++ b)
+            Seq.iterate (fn (a, b) => a ++ space ++ b)
               (token (MaybeLongToken.getToken (Seq.nth elems 0)))
               (Seq.zipWith showOne (delims, Seq.drop elems 1))
         in
-          group (
-            showSpec spec
-            $$
-            rigid (token sharingg ++ space ++ token typee ++ space ++ stuff)
-          )
+          group
+            (showSpec spec
+             $$ rigid (token sharingg ++ space ++ token typee ++ space ++ stuff))
         end
 
 
   and showSigExp sigexp =
     case sigexp of
-      Ast.Sig.Ident id =>
-        token id
+      Ast.Sig.Ident id => token id
 
     | Ast.Sig.Spec {sigg, spec, endd} =>
-        group (
-          token sigg
-          $$
-          indent (showSpec spec)
-          $$
-          token endd
-        )
+        group (token sigg $$ indent (showSpec spec) $$ token endd)
 
     | Ast.Sig.WhereType {sigexp, elems} =>
         let
           val se = showSigExp sigexp
 
           fun showElem {wheree, typee, tyvars, tycon, eq, ty} =
-            indent (
-              separateWithSpaces
-                [ SOME (token wheree) (** this could be 'and' *)
-                , SOME (token typee)
-                , maybeShowSyntaxSeq tyvars token
-                , SOME (token (MaybeLongToken.getToken tycon))
-                , SOME (token eq)
-                , SOME (showTy ty)
-                ]
-            )
+            indent (separateWithSpaces
+              [ SOME (token wheree) (** this could be 'and' *)
+              , SOME (token typee)
+              , maybeShowSyntaxSeq tyvars token
+              , SOME (token (MaybeLongToken.getToken tycon))
+              , SOME (token eq)
+              , SOME (showTy ty)
+              ])
         in
           Seq.iterate op$$ se (Seq.map showElem elems)
         end
@@ -278,15 +229,11 @@ struct
   fun showSigDec (Ast.Sig.Signature {signaturee, elems, delims}) =
     let
       fun showOne (starter, {ident, eq, sigexp}) =
-        group (
-          (token starter
-          ++ space ++ token ident ++ space ++ token eq)
-          $$
-          indent (showSigExp sigexp)
-        )
+        group
+          ((token starter ++ space ++ token ident ++ space ++ token eq)
+           $$ indent (showSigExp sigexp))
     in
-      rigidVertically
-        (showOne (signaturee, Seq.nth elems 0))
+      rigidVertically (showOne (signaturee, Seq.nth elems 0))
         (Seq.zipWith showOne (delims, Seq.drop elems 1))
     end
 

--- a/src/pretty-print/PrettyStr.sml
+++ b/src/pretty-print/PrettyStr.sml
@@ -26,67 +26,39 @@ struct
 
   fun showStrExp e =
     case e of
-      Ast.Str.Ident id =>
-        token (MaybeLongToken.getToken id)
+      Ast.Str.Ident id => token (MaybeLongToken.getToken id)
 
-    | Ast.Str.Struct {structt, strdec, endd} => (
-        case strdec of
-          Ast.Str.DecEmpty => token structt ++ space ++ token endd
-        | _ =>
-            rigid (
-              token structt
-              $$
-              indent (showStrDec strdec)
-              $$
-              token endd
-            )
-      )
+    | Ast.Str.Struct {structt, strdec, endd} =>
+        (case strdec of
+           Ast.Str.DecEmpty => token structt ++ space ++ token endd
+         | _ =>
+             rigid (token structt $$ indent (showStrDec strdec) $$ token endd))
 
     | Ast.Str.Constraint {strexp, colon, sigexp} =>
-        showStrExp strexp
-        ++ space ++ token colon
-        \\ showSigExp sigexp
+        showStrExp strexp ++ space ++ token colon \\ showSigExp sigexp
 
     | Ast.Str.FunAppExp {funid, lparen, strexp, rparen} =>
-        token funid
-        \\ token lparen ++ showStrExp strexp ++ token rparen
+        token funid \\ token lparen ++ showStrExp strexp ++ token rparen
 
     | Ast.Str.FunAppDec {funid, lparen, strdec, rparen} =>
-        token funid
-        \\ token lparen ++ showStrDec strdec ++ token rparen
+        token funid \\ token lparen ++ showStrDec strdec ++ token rparen
 
     | Ast.Str.LetInEnd {lett, strdec, inn, strexp, endd} =>
         let
-          val topPart =
-            token lett
-            $$
-            indent (showStrDec strdec)
-            $$
-            token inn
+          val topPart = token lett $$ indent (showStrDec strdec) $$ token inn
 
           val topPart =
-            if Ast.Str.isMultipleDecs strdec then
-              topPart
-            else
-              group topPart
+            if Ast.Str.isMultipleDecs strdec then topPart else group topPart
         in
-          group (
-            topPart
-            $$
-            indent (group (showStrExp strexp))
-            $$
-            token endd
-          )
+          group (topPart $$ indent (group (showStrExp strexp)) $$ token endd)
         end
 
 
   and showStrDec d =
     case d of
-      Ast.Str.DecEmpty =>
-        empty
+      Ast.Str.DecEmpty => empty
 
-    | Ast.Str.DecCore d =>
-        showDec d
+    | Ast.Str.DecCore d => showDec d
 
     | Ast.Str.DecStructure {structuree, elems, delims} =>
         let
@@ -94,18 +66,15 @@ struct
             separateWithSpaces
               [ SOME (token starter)
               , SOME (token strid)
-              , Option.map
-                  (fn {colon, ...} => token colon)
-                  constraint
+              , Option.map (fn {colon, ...} => token colon) constraint
               ]
-            \\ separateWithSpaces
-                  [ Option.map (fn {sigexp, ...} => showSigExp sigexp) constraint
-                  , SOME (token eq)
-                  ]
-            \\ showStrExp strexp
+            \\
+            separateWithSpaces
+              [ Option.map (fn {sigexp, ...} => showSigExp sigexp) constraint
+              , SOME (token eq)
+              ] \\ showStrExp strexp
         in
-          rigidVertically
-            (showOne (structuree, Seq.nth elems 0))
+          rigidVertically (showOne (structuree, Seq.nth elems 0))
             (Seq.map showOne (Seq.zip (delims, (Seq.drop elems 1))))
         end
 
@@ -115,51 +84,39 @@ struct
             showStrDec (Seq.nth elems i)
             ++
             (case Seq.nth delims i of
-              NONE => empty
-            | SOME sc => token sc)
+               NONE => empty
+             | SOME sc => token sc)
         in
-          rigid (Util.loop (0, Seq.length elems) empty (fn (prev, i) => prev $$ f i))
+          rigid (Util.loop (0, Seq.length elems) empty (fn (prev, i) =>
+            prev $$ f i))
         end
 
     | Ast.Str.DecLocalInEnd {locall, strdec1, inn, strdec2, endd} =>
-        rigid (
-          token locall
-          $$
-          indent (showStrDec strdec1)
-          $$
-          token inn
-          $$
-          indent (showStrDec strdec2)
-          $$
-          token endd
-        )
+        rigid
+          (token locall $$ indent (showStrDec strdec1) $$ token inn
+           $$ indent (showStrDec strdec2) $$ token endd)
 
     (** This is MLton-specific. Useful for testing by parsing the entire
       * MLton implementation of the standard basis.
       *)
     | Ast.Str.MLtonOverload
-      {underscore, overload, prec, name, colon, ty, ass, elems, delims} =>
+        {underscore, overload, prec, name, colon, ty, ass, elems, delims} =>
         let
           val front =
-            token underscore ++ token overload
-            ++ space ++ token prec
-            ++ space ++ token name
-            ++ space ++ token colon
-            ++ space ++ showTy ty
-            ++ space ++ token ass
+            token underscore ++ token overload ++ space ++ token prec ++ space
+            ++ token name ++ space ++ token colon ++ space ++ showTy ty ++ space
+            ++ token ass
 
           fun showOne (d, e) =
             token d ++ space ++ token (MaybeLongToken.getToken e)
         in
-          group (
-            front
-            $$
-            indent (
-              rigidVertically
-                (token (MaybeLongToken.getToken (Seq.nth elems 0)))
-                (Seq.zipWith showOne (delims, Seq.drop elems 1))
-            )
-          )
+          group
+            (front
+             $$
+             indent
+               (rigidVertically
+                  (token (MaybeLongToken.getToken (Seq.nth elems 0)))
+                  (Seq.zipWith showOne (delims, Seq.drop elems 1))))
         end
 
 end

--- a/src/pretty-print/PrettyTy.sml
+++ b/src/pretty-print/PrettyTy.sml
@@ -13,42 +13,45 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ // +/+ +$+
-  fun x ++ y = beside (x, y)
-  fun x $$ y = aboveOrSpace (x, y)
-  fun x // y = aboveOrBeside (x, y)
+  fun x ++ y =
+    beside (x, y)
+  fun x $$ y =
+    aboveOrSpace (x, y)
+  fun x // y =
+    aboveOrBeside (x, y)
 
-  fun x +/+ y = besideAndAbove (x, y)
-  fun x +$+ y = besideAndAboveOrSpace (x, y)
+  fun x +/+ y =
+    besideAndAbove (x, y)
+  fun x +$+ y =
+    besideAndAboveOrSpace (x, y)
 
   fun showTy ty =
     let
       open Ast.Ty
     in
       case ty of
-        Var tok =>
-          token tok
+        Var tok => token tok
       | Con {args = Ast.SyntaxSeq.Empty, id} =>
           token (MaybeLongToken.getToken id)
       | Con {args, id} =>
           (separateWithSpaces
-            [ maybeShowSyntaxSeq args showTy
-            , SOME (token (MaybeLongToken.getToken id))
-            ])
-      | Parens {left, ty, right} =>
-          token left ++ showTy ty ++ token right
+             [ maybeShowSyntaxSeq args showTy
+             , SOME (token (MaybeLongToken.getToken id))
+             ])
+      | Parens {left, ty, right} => token left ++ showTy ty ++ token right
       | Tuple {elems, delims} =>
           let
             val begin = showTy (Seq.nth elems 0)
-            fun f (delim, x) = space ++ token delim ++ space ++ showTy x
+            fun f (delim, x) =
+              space ++ token delim ++ space ++ showTy x
           in
-            Seq.iterate op++ begin
-              (Seq.map f (Seq.zip (delims, Seq.drop elems 1)))
+            Seq.iterate op++ begin (Seq.map f (Seq.zip
+              (delims, Seq.drop elems 1)))
           end
       | Record {left, elems, delims, right} =>
           let
             fun showElem {lab, colon, ty} =
-              token lab ++ space ++ token colon
-              ++ space ++ showTy ty
+              token lab ++ space ++ token colon ++ space ++ showTy ty
           in
             sequence left delims right (Seq.map showElem elems)
           end
@@ -60,8 +63,7 @@ struct
                   showTy l
                   $$ ((spaces 2 ++ token arrow) +$+ show_arrow l' arrow' r')
               | (_, Arrow _) =>
-                  showTy l
-                  $$ (spaces 2 ++ token arrow ++ space ++ showTy r)
+                  showTy l $$ (spaces 2 ++ token arrow ++ space ++ showTy r)
               | _ => showTy l ++ space ++ token arrow ++ space ++ showTy r
           in
             group (show_arrow left arrow right)

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -9,17 +9,21 @@ struct
   open TokenDoc
   infix 2 ++ $$ //
   infix 1 \\
-  fun x ++ y = beside (x, y)
-  fun x $$ y = aboveOrSpace (x, y)
-  fun x // y = aboveOrBeside (x, y)
-  fun x \\ y = group (x $$ indent y)
+  fun x ++ y =
+    beside (x, y)
+  fun x $$ y =
+    aboveOrSpace (x, y)
+  fun x // y =
+    aboveOrBeside (x, y)
+  fun x \\ y =
+    group (x $$ indent y)
 
   fun seqWithSpaces elems f =
-    if Seq.length elems = 0 then empty else
-    Seq.iterate
-      (fn (prev, tok) => prev ++ space ++ f tok)
-      (f (Seq.nth elems 0))
-      (Seq.drop elems 1)
+    if Seq.length elems = 0 then
+      empty
+    else
+      Seq.iterate (fn (prev, tok) => prev ++ space ++ f tok)
+        (f (Seq.nth elems 0)) (Seq.drop elems 1)
 
 
   fun spaces n =
@@ -32,13 +36,12 @@ struct
     else
       let
         val top = token openn ++ softspace ++ Seq.nth xs 0
-        fun f (delim, x) = token delim ++ space ++ x
+        fun f (delim, x) =
+          token delim ++ space ++ x
       in
-        group (
-          Seq.iterate op// top (Seq.map f (Seq.zip (delims, Seq.drop xs 1)))
-          //
-          token close
-        )
+        group
+          (Seq.iterate op// top (Seq.map f (Seq.zip (delims, Seq.drop xs 1)))
+           // token close)
       end
 
 
@@ -53,8 +56,7 @@ struct
     end
 
   fun rigidVertically (item: doc) (items: doc Seq.t) : doc =
-    if Seq.length items = 0 then item else
-      rigid (Seq.iterate op$$ item items)
+    if Seq.length items = 0 then item else rigid (Seq.iterate op$$ item items)
 
 
   fun maybeShowSyntaxSeq s f =

--- a/src/pretty-print/StringDoc.sml
+++ b/src/pretty-print/StringDoc.sml
@@ -1,2 +1,1 @@
-structure StringDoc =
-  PrettySimpleDoc(TerminalColorString)
+structure StringDoc = PrettySimpleDoc(TerminalColorString)

--- a/src/pretty-print/TokenDoc.sml
+++ b/src/pretty-print/TokenDoc.sml
@@ -107,28 +107,25 @@ struct
   fun insertBlankLines doc =
     let
       fun blankLinesAbove d n =
-        if n <= 0 then d else blankLinesAbove (Above (false, space, d)) (n-1)
+        if n <= 0 then d else blankLinesAbove (Above (false, space, d)) (n - 1)
 
-      fun preferRight (a, b) = if Option.isSome b then b else a
-      fun preferLeft (a, b) = if Option.isSome a then a else b
+      fun preferRight (a, b) =
+        if Option.isSome b then b else a
+      fun preferLeft (a, b) =
+        if Option.isSome a then a else b
 
       fun doDoc doc =
         case doc of
-          Token tok =>
-            (SOME tok, doc, SOME tok)
+          Token tok => (SOME tok, doc, SOME tok)
 
         | Indent d =>
-            let
-              val (first, d', last) = doDoc d
-            in
-              (first, Indent d', last)
+            let val (first, d', last) = doDoc d
+            in (first, Indent d', last)
             end
 
         | Group d =>
-            let
-              val (first, d', last) = doDoc d
-            in
-              (first, Group d', last)
+            let val (first, d', last) = doDoc d
+            in (first, Group d', last)
             end
 
         | Beside (d1, d2) =>
@@ -172,17 +169,14 @@ struct
                       Above (b, d1', blankLinesAbove d2' diff)
                     end
 
-                | _ =>
-                    Above (b, d1', d2')
+                | _ => Above (b, d1', d2')
             in
               (first, result, last)
             end
 
         | Rigid d =>
-            let
-              val (first, d', last) = doDoc d
-            in
-              (first, Rigid d', last)
+            let val (first, d', last) = doDoc d
+            in (first, Rigid d', last)
             end
 
         | _ => (NONE, doc, NONE)
@@ -205,25 +199,13 @@ struct
         let
           val (resultDoc, cb, ca) =
             if hasToks1 andalso hasToks2 then
-              ( bin (d1, bin (ca1, bin (cb2, d2)))
-              , cb1
-              , ca2
-              )
+              (bin (d1, bin (ca1, bin (cb2, d2))), cb1, ca2)
             else if hasToks1 andalso not hasToks2 then
-              ( bin (d1, d2)
-              , cb1
-              , bin (ca1, bin (cb2, ca2))
-              )
+              (bin (d1, d2), cb1, bin (ca1, bin (cb2, ca2)))
             else if not hasToks1 andalso hasToks2 then
-              ( bin (d1, d2)
-              , bin (cb1, bin (ca1, cb2))
-              , ca2
-              )
+              (bin (d1, d2), bin (cb1, bin (ca1, cb2)), ca2)
             else
-              ( bin (d1, d2)
-              , bin (cb1, bin (ca1, bin (cb2, ca2)))
-              , Empty
-              )
+              (bin (d1, d2), bin (cb1, bin (ca1, bin (cb2, ca2))), Empty)
         in
           (hasToks1 orelse hasToks2, resultDoc, cb, ca)
         end
@@ -231,10 +213,8 @@ struct
       (* returns (containsTokens?, doc', commentsBefore, commentsAfter) *)
       fun loop doc =
         case doc of
-          Empty =>
-            (false, Empty, Empty, Empty)
-        | Space b =>
-            (false, Space b, Empty, Empty)
+          Empty => (false, Empty, Empty, Empty)
+        | Space b => (false, Space b, Empty, Empty)
         | Indent doc =>
             let
               val (hasToks, doc', cb, ca) = loop doc
@@ -245,20 +225,15 @@ struct
                 (false, Indent doc', cb, ca)
             end
         | Token t =>
-            if Token.isComment t then
-              (false, Empty, Token t, Empty)
-            else
-              (true, Token t, Empty, Empty)
-        | Beside (d1, d2) =>
-            combine beside (loop d1) (loop d2)
+            if Token.isComment t then (false, Empty, Token t, Empty)
+            else (true, Token t, Empty, Empty)
+        | Beside (d1, d2) => combine beside (loop d1) (loop d2)
         | BesideAndAbove (withSpace, d1, d2) =>
             combine (besideAndAbove' withSpace) (loop d1) (loop d2)
         | Above (withSpace, d1, d2) =>
             combine (above' withSpace) (loop d1) (loop d2)
-        | Group doc =>
-            modifyDoc Group (loop doc)
-        | Rigid doc =>
-            modifyDoc Rigid (loop doc)
+        | Group doc => modifyDoc Group (loop doc)
+        | Rigid doc => modifyDoc Rigid (loop doc)
 
       val (_, doc, commBefore, commAfter) = loop doc
     in
@@ -270,8 +245,7 @@ struct
     let
       (** Does this doc most recently appear beside something,
         * or below something?
-        *)
-      datatype mode = BesideMode | AboveMode
+        *) datatype mode = BesideMode | AboveMode
 
       fun tokens mode toks =
         let
@@ -291,39 +265,29 @@ struct
 
       fun insertAllBefore mode d =
         case d of
-          Empty =>
-            Empty
-        | Space b =>
-            Space b
-        | Indent d =>
-            Indent (insertAllBefore mode d)
-        | Token tok =>
-            insertCommentsBeforeTok mode tok
+          Empty => Empty
+        | Space b => Space b
+        | Indent d => Indent (insertAllBefore mode d)
+        | Token tok => insertCommentsBeforeTok mode tok
         | Beside (d1, d2) =>
             Beside (insertAllBefore mode d1, insertAllBefore BesideMode d2)
         | BesideAndAbove (b, d1, d2) =>
-            BesideAndAbove (b, insertAllBefore mode d1, insertAllBefore BesideMode d2)
+            BesideAndAbove
+              (b, insertAllBefore mode d1, insertAllBefore BesideMode d2)
         | Above (b, d1, d2) =>
             Above (b, insertAllBefore mode d1, insertAllBefore AboveMode d2)
-        | Group d =>
-            Group (insertAllBefore mode d)
-        | Rigid d =>
-            Rigid (insertAllBefore mode d)
+        | Group d => Group (insertAllBefore mode d)
+        | Rigid d => Rigid (insertAllBefore mode d)
 
       fun insertOnlyAfterLast mode d =
         case d of
-          Empty =>
-            (false, Empty)
-        | Space b =>
-            (false, Space b)
+          Empty => (false, Empty)
+        | Space b => (false, Space b)
         | Indent d =>
-            let
-              val (foundIt, d') = insertOnlyAfterLast mode d
-            in
-              (foundIt, Indent d')
+            let val (foundIt, d') = insertOnlyAfterLast mode d
+            in (foundIt, Indent d')
             end
-        | Token tok =>
-            (true, insertCommentsAfterTok mode tok)
+        | Token tok => (true, insertCommentsAfterTok mode tok)
         | Beside (d1, d2) =>
             let
               val (foundIt, d2') = insertOnlyAfterLast BesideMode d2
@@ -331,10 +295,8 @@ struct
               if foundIt then
                 (true, Beside (d1, d2'))
               else
-                let
-                  val (foundIt, d1') = insertOnlyAfterLast mode d1
-                in
-                  (foundIt, Beside (d1', d2'))
+                let val (foundIt, d1') = insertOnlyAfterLast mode d1
+                in (foundIt, Beside (d1', d2'))
                 end
             end
         | BesideAndAbove (b, d1, d2) =>
@@ -344,10 +306,8 @@ struct
               if foundIt then
                 (true, BesideAndAbove (b, d1, d2'))
               else
-                let
-                  val (foundIt, d1') = insertOnlyAfterLast mode d1
-                in
-                  (foundIt, BesideAndAbove (b, d1', d2'))
+                let val (foundIt, d1') = insertOnlyAfterLast mode d1
+                in (foundIt, BesideAndAbove (b, d1', d2'))
                 end
             end
         | Above (b, d1, d2) =>
@@ -357,23 +317,17 @@ struct
               if foundIt then
                 (true, Above (b, d1, d2'))
               else
-                let
-                  val (foundIt, d1') = insertOnlyAfterLast mode d1
-                in
-                  (foundIt, Above (b, d1', d2'))
+                let val (foundIt, d1') = insertOnlyAfterLast mode d1
+                in (foundIt, Above (b, d1', d2'))
                 end
             end
         | Group d =>
-            let
-              val (foundIt, d') = insertOnlyAfterLast mode d
-            in
-              (foundIt, Group d')
+            let val (foundIt, d') = insertOnlyAfterLast mode d
+            in (foundIt, Group d')
             end
         | Rigid d =>
-            let
-              val (foundIt, d') = insertOnlyAfterLast mode d
-            in
-              (foundIt, Rigid d')
+            let val (foundIt, d') = insertOnlyAfterLast mode d
+            in (foundIt, Rigid d')
             end
 
       val doc = insertAllBefore AboveMode doc
@@ -394,17 +348,18 @@ struct
         *)
       val effectiveOffset =
         let
-          val {col, line=lineNum} = Source.absoluteStart src
-          val len = col-1
+          val {col, line = lineNum} = Source.absoluteStart src
+          val len = col - 1
           val charsBeforeOnSameLine =
             Source.take (Source.wholeLine src lineNum) len
           fun loop effOff i =
-            if i >= len then effOff
+            if i >= len then
+              effOff
             else if #"\t" = Source.nth charsBeforeOnSameLine i then
               (* advance up to next tabstop *)
-              loop (effOff + tabWidth - effOff mod tabWidth) (i+1)
+              loop (effOff + tabWidth - effOff mod tabWidth) (i + 1)
             else
-              loop (effOff+1) (i+1)
+              loop (effOff + 1) (i + 1)
         in
           loop 0 0
         end
@@ -413,8 +368,7 @@ struct
         let
           val (_, ln) =
             TCS.stripEffectiveWhitespace
-              {tabWidth=tabWidth, removeAtMost=effectiveOffset}
-              line
+              {tabWidth = tabWidth, removeAtMost = effectiveOffset} line
         in
           ln
         end
@@ -423,33 +377,28 @@ struct
 
       val pieces =
         Seq.map
-          (fn (i, j) => StringDoc.text (strip (TCS.substring (t, i, j-i))))
+          (fn (i, j) => StringDoc.text (strip (TCS.substring (t, i, j - i))))
           (Source.lineRanges src)
-
-      (* val _ =
-        let
-          val ss = Token.toString tok
-          val ranges = Source.lineRanges src
-          val lines = Seq.map (fn (i, j) => TCS.substring (t, i, j-i)) ranges
-          val stripped = Seq.map strip lines
-          fun p s = Util.for (0, Seq.length s) (fn i =>
-            print (String.toString (TCS.toString {colors=false} (Seq.nth s i)) ^ "\n"))
-        in
-          print ("------- token -------\n");
-          print (String.toString ss ^ "\n");
-          print ("------- lines -------\n");
-          p lines;
-          print ("------- strip -------\n");
-          p stripped;
-          print ("---------------------\n")
-        end *)
+        (* val _ =
+          let
+            val ss = Token.toString tok
+            val ranges = Source.lineRanges src
+            val lines = Seq.map (fn (i, j) => TCS.substring (t, i, j-i)) ranges
+            val stripped = Seq.map strip lines
+            fun p s = Util.for (0, Seq.length s) (fn i =>
+              print (String.toString (TCS.toString {colors=false} (Seq.nth s i)) ^ "\n"))
+          in
+            print ("------- token -------\n");
+            print (String.toString ss ^ "\n");
+            print ("------- lines -------\n");
+            p lines;
+            print ("------- strip -------\n");
+            p stripped;
+            print ("---------------------\n")
+          end *)
     in
-      if Seq.length pieces = 1 then
-        (true, StringDoc.text t)
-      else
-        ( false
-        , Seq.iterate StringDoc.aboveOrSpace StringDoc.empty pieces
-        )
+      if Seq.length pieces = 1 then (true, StringDoc.text t)
+      else (false, Seq.iterate StringDoc.aboveOrSpace StringDoc.empty pieces)
     end
 
 
@@ -458,23 +407,17 @@ struct
       (** returns whether or not allowed to be grouped *)
       fun loop d =
         case d of
-          Empty =>
-            (true, StringDoc.empty)
+          Empty => (true, StringDoc.empty)
 
-        | Space true =>
-            (true, StringDoc.space)
+        | Space true => (true, StringDoc.space)
 
-        | Space false =>
-            (true, StringDoc.softspace)
+        | Space false => (true, StringDoc.softspace)
 
-        | Token t =>
-            tokenToStringDoc tabWidth t
+        | Token t => tokenToStringDoc tabWidth t
 
         | Indent d =>
-            let
-              val (groupable, d') = loop d
-            in
-              (groupable, StringDoc.indent d')
+            let val (groupable, d') = loop d
+            in (groupable, StringDoc.indent d')
             end
 
         | Beside (d1, d2) =>
@@ -491,10 +434,8 @@ struct
               val (g2, d2') = loop d2
             in
               ( g1 andalso g2
-              , if b then
-                  StringDoc.besideAndAboveOrSpace (d1', d2')
-                else
-                  StringDoc.besideAndAbove (d1', d2')
+              , if b then StringDoc.besideAndAboveOrSpace (d1', d2')
+                else StringDoc.besideAndAbove (d1', d2')
               )
             end
 
@@ -504,29 +445,17 @@ struct
               val (g2, d2') = loop d2
             in
               ( g1 andalso g2
-              , if b then
-                  StringDoc.aboveOrSpace (d1', d2')
-                else
-                  StringDoc.aboveOrBeside (d1', d2')
+              , if b then StringDoc.aboveOrSpace (d1', d2')
+                else StringDoc.aboveOrBeside (d1', d2')
               )
             end
 
         | Group d =>
-            let
-              val (groupable, d') = loop d
-            in
-              if groupable then
-                (true, StringDoc.group d')
-              else
-                (false, d')
+            let val (groupable, d') = loop d
+            in if groupable then (true, StringDoc.group d') else (false, d')
             end
 
-        | Rigid d =>
-            let
-              val (_, d') = loop d
-            in
-              (false, StringDoc.rigid d')
-            end
+        | Rigid d => let val (_, d') = loop d in (false, StringDoc.rigid d') end
 
       val (_, d') = loop d
     in

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -5,33 +5,34 @@
 
 structure TCS = TerminalColorString
 structure TC = TerminalColors
-fun boldc c x = TCS.bold (TCS.foreground c (TCS.fromString x))
-fun printErr m = TextIO.output (TextIO.stdErr, m)
+fun boldc c x =
+  TCS.bold (TCS.foreground c (TCS.fromString x))
+fun printErr m =
+  TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
-"  [--force]              overwrite files without interactive confirmation\n\
-\  [--preview]            show formatted before writing to file\n\
-\  [--preview-only]       show formatted output and skip file overwrite\n\
-\                         (incompatible with --force)\n\
-\  [-max-width W]         try to use at most <W> columns in each line\n\
-\                         (default 80)\n\
-\  [-ribbon-frac R]       controls how dense each line should be\n\
-\                         (default 1.0; requires 0 < R <= 1)\n\
-\  [-tab-width T]         parse input tab-stops as having width <T>\n\
-\                         (default 4)\n\
-\  [-indent-width I]      use <I> spaces for indentation in output\n\
-\                         (default 2)\n\
-\  [-mlb-path-var 'K V']  MLton-style path variable\n\
-\  [-engine E]            Select a pretty printing engine.\n\
-\                         Valid options are: prettier, pretty\n\
-\                         (default 'prettier')\n\
-\  [--debug-engine]       Enable debugging output (for devs)\n\
-\  [--help]               print this message\n"
+  "  [--force]              overwrite files without interactive confirmation\n\
+  \  [--preview]            show formatted before writing to file\n\
+  \  [--preview-only]       show formatted output and skip file overwrite\n\
+  \                         (incompatible with --force)\n\
+  \  [-max-width W]         try to use at most <W> columns in each line\n\
+  \                         (default 80)\n\
+  \  [-ribbon-frac R]       controls how dense each line should be\n\
+  \                         (default 1.0; requires 0 < R <= 1)\n\
+  \  [-tab-width T]         parse input tab-stops as having width <T>\n\
+  \                         (default 4)\n\
+  \  [-indent-width I]      use <I> spaces for indentation in output\n\
+  \                         (default 2)\n\
+  \  [-mlb-path-var 'K V']  MLton-style path variable\n\
+  \  [-engine E]            Select a pretty printing engine.\n\
+  \                         Valid options are: prettier, pretty\n\
+  \                         (default 'prettier')\n\
+  \  [--debug-engine]       Enable debugging output (for devs)\n\
+  \  [--help]               print this message\n"
 
 fun usage () =
-  "usage: smlfmt [ARGS] FILE ... FILE\n" ^
-  "Optional arguments:\n" ^
-  optionalArgDesc
+  "usage: smlfmt [ARGS] FILE ... FILE\n" ^ "Optional arguments:\n"
+  ^ optionalArgDesc
 
 
 val mlbPathVars = CommandLineArgs.parseStrings "mlb-path-var"
@@ -52,26 +53,27 @@ val showPreview = preview orelse previewOnly
 
 val _ =
   if doHelp orelse List.null inputfiles then
-    ( print (usage ())
-    ; OS.Process.exit OS.Process.success
-    )
-  else ()
+    (print (usage ()); OS.Process.exit OS.Process.success)
+  else
+    ()
 
 val _ =
   if previewOnly andalso doForce then
-    ( TCS.printErr (boldc Palette.red
-        "ERROR: --force incompatible with --preview-only\n")
+    ( TCS.printErr
+        (boldc Palette.red "ERROR: --force incompatible with --preview-only\n")
     ; OS.Process.exit OS.Process.failure
     )
-  else ()
+  else
+    ()
 
 val _ =
   if doDebug andalso not (previewOnly) then
-    ( TCS.printErr (boldc Palette.red
-        "ERROR: --debug-engine requires --preview-only\n")
+    ( TCS.printErr
+        (boldc Palette.red "ERROR: --debug-engine requires --preview-only\n")
     ; OS.Process.exit OS.Process.failure
     )
-  else ()
+  else
+    ()
 
 val prettyPrinter =
   case engine of
@@ -79,8 +81,7 @@ val prettyPrinter =
   | "pretty" => PrettyPrintAst.pretty
   | other =>
       ( TCS.printErr (boldc Palette.red
-          ("ERROR: unknown engine '"
-           ^ other
+          ("ERROR: unknown engine '" ^ other
            ^ "'; valid options are: prettier, pretty\n"))
       ; OS.Process.exit OS.Process.failure
       )
@@ -100,8 +101,8 @@ fun handleLexOrParseError exn =
   in
     TCS.print
       (Error.show {highlighter = SOME SyntaxHighlighter.fuzzyHighlight} e);
-    if List.null hist then () else
-      print ("\n" ^ String.concat (List.map (fn ln => ln ^ "\n") hist));
+    if List.null hist then ()
+    else print ("\n" ^ String.concat (List.map (fn ln => ln ^ "\n") hist));
     OS.Process.exit OS.Process.failure
   end
 
@@ -113,7 +114,8 @@ fun exnToString exn =
       if List.null (MLton.Exn.history exn) then
         ""
       else
-        "\nSTACK TRACE:\n" ^
+        "\nSTACK TRACE:\n"
+        ^
         List.foldl op^ ""
           (List.map (fn s => "  " ^ s ^ "\n") (MLton.Exn.history exn))
   in
@@ -133,8 +135,7 @@ fun doSMLAst (fp, parserOutput) =
             , maxWidth = maxWidth
             , indentWidth = indentWidth
             , debug = doDebug
-            }
-            (TabbedTokenDoc.justCommentsToStringDoc {tabWidth=tabWidth} cs)
+            } (TabbedTokenDoc.justCommentsToStringDoc {tabWidth = tabWidth} cs)
 
       | Parser.Ast ast =>
           prettyPrinter
@@ -143,10 +144,9 @@ fun doSMLAst (fp, parserOutput) =
             , tabWidth = tabWidth
             , indent = indentWidth
             , debug = doDebug
-            }
-            ast
+            } ast
 
-    val result = TCS.toString {colors=false} prettied
+    val result = TCS.toString {colors = false} prettied
 
     fun writeOut () =
       let
@@ -163,13 +163,12 @@ fun doSMLAst (fp, parserOutput) =
       ; case TextIO.inputLine TextIO.stdIn of
           NONE => printErr ("skipping " ^ hfp ^ "\n")
         | SOME line =>
-            if line = "y\n" orelse line = "Y\n" then
-              writeOut ()
-            else
-              printErr ("skipping " ^ hfp ^ "\n")
+            if line = "y\n" orelse line = "Y\n" then writeOut ()
+            else printErr ("skipping " ^ hfp ^ "\n")
       )
   in
-    if not showPreview then ()
+    if not showPreview then
+      ()
     else
       ( TCS.print (boldc Palette.lightblue ("---- " ^ hfp ^ " ----"))
       ; print "\n"
@@ -179,23 +178,17 @@ fun doSMLAst (fp, parserOutput) =
       ; print "\n"
       );
 
-    if previewOnly then ()
-    else if doForce then
-      writeOut ()
-    else
-      confirm ()
+    if previewOnly then () else if doForce then writeOut () else confirm ()
   end
-  handle exn =>
-    TCS.printErr (boldc Palette.red (exnToString exn ^ "\n"))
+  handle exn => TCS.printErr (boldc Palette.red (exnToString exn ^ "\n"))
 
 
 fun doSML filepath =
   let
     val fp = FilePath.fromUnixPath filepath
     val source = Source.loadFromFile fp
-    val result =
-      Parser.parse {allowTopExp = allowTopExp} source
-      handle exn => handleLexOrParseError exn
+    val result = Parser.parse {allowTopExp = allowTopExp} source
+                 handle exn => handleLexOrParseError exn
   in
     doSMLAst (fp, result)
   end
@@ -205,12 +198,11 @@ fun doMLB filepath =
   let
     val fp = FilePath.fromUnixPath filepath
     val asts =
-      ParseAllSMLFromMLB.parse {skipBasis = true, pathmap = pathmap, allowTopExp = allowTopExp} fp
+      ParseAllSMLFromMLB.parse
+        {skipBasis = true, pathmap = pathmap, allowTopExp = allowTopExp} fp
       handle exn => handleLexOrParseError exn
   in
-    Util.for (0, Seq.length asts) (fn i =>
-      doSMLAst (Seq.nth asts i)
-    )
+    Util.for (0, Seq.length asts) (fn i => doSMLAst (Seq.nth asts i))
   end
 
 
@@ -229,27 +221,29 @@ fun fileinfo filepath =
       NONE => MissingExtension
     | SOME "mlb" => MLBFile
     | SOME e =>
-        if List.exists (fn e' => e = e') ["sml","fun","sig"] then
-          SMLFile
-        else
-          Unsupported e
+        if List.exists (fn e' => e = e') ["sml", "fun", "sig"] then SMLFile
+        else Unsupported e
   end
   handle exn => FileError exn
 
 fun okayFile (filepath, info) =
-  case info of SMLFile => true | MLBFile => true | _ => false
+  case info of
+    SMLFile => true
+  | MLBFile => true
+  | _ => false
 
 fun skipFile (filepath, info) =
-  printErr ("skipping file " ^ filepath ^ ": "
-  ^ (case info of
-      MissingExtension => "missing extension"
-    | Unsupported e => "unsupported file extension: " ^ e
-    | FileError exn => exnMessage exn
-    | _ => raise Fail "Error! Bug! Please submit an error report...")
-  ^ "\n")
+  printErr
+    ("skipping file " ^ filepath ^ ": "
+     ^
+     (case info of
+        MissingExtension => "missing extension"
+      | Unsupported e => "unsupported file extension: " ^ e
+      | FileError exn => exnMessage exn
+      | _ => raise Fail "Error! Bug! Please submit an error report...") ^ "\n")
 
-val (filesToDo, filesToSkip) =
-  List.partition okayFile (List.map (fn x => (x, fileinfo x)) inputfiles)
+val (filesToDo, filesToSkip) = List.partition okayFile
+  (List.map (fn x => (x, fileinfo x)) inputfiles)
 
 fun doFile (fp, info) =
   case info of
@@ -257,8 +251,6 @@ fun doFile (fp, info) =
   | MLBFile => doMLB fp
   | _ => raise Fail "Error! Bug! Please submit an error report..."
 
-val _ =
-  List.app skipFile filesToSkip
+val _ = List.app skipFile filesToSkip
 
-val _ =
-  List.app doFile filesToDo
+val _ = List.app doFile filesToDo

--- a/src/syntax-highlighting/SyntaxHighlighter.sml
+++ b/src/syntax-highlighting/SyntaxHighlighter.sml
@@ -25,28 +25,17 @@ struct
 
   fun tokColor class =
     case class of
-      Token.StringConstant =>
-        TCS.foreground red
-    | Token.CharConstant =>
-        TCS.foreground purple
-    | Token.WordConstant =>
-        TCS.foreground yellow
-    | Token.Comment =>
-        TCS.italic o TCS.foreground gray
-    | Token.IntegerConstant =>
-        TCS.foreground lightblue
-    | Token.RealConstant =>
-        TCS.foreground green
-    | Token.Reserved _ =>
-        TCS.bold o TCS.foreground blue
-    | Token.LongIdentifier =>
-        TCS.foreground pink
-    | Token.Identifier =>
-        TCS.foreground darkgreen
-    | Token.MLtonReserved =>
-        TCS.foreground darkgreen
-    | Token.Whitespace =>
-        TCS.clear
+      Token.StringConstant => TCS.foreground red
+    | Token.CharConstant => TCS.foreground purple
+    | Token.WordConstant => TCS.foreground yellow
+    | Token.Comment => TCS.italic o TCS.foreground gray
+    | Token.IntegerConstant => TCS.foreground lightblue
+    | Token.RealConstant => TCS.foreground green
+    | Token.Reserved _ => TCS.bold o TCS.foreground blue
+    | Token.LongIdentifier => TCS.foreground pink
+    | Token.Identifier => TCS.foreground darkgreen
+    | Token.MLtonReserved => TCS.foreground darkgreen
+    | Token.Whitespace => TCS.clear
 
   (* fun tokColorMLB class =
     case class of
@@ -70,20 +59,24 @@ struct
 
 
   fun loop tokColor acc (wholeSrc, i, stop) (toks, j) =
-    if i >= stop then
+    if
+      i >= stop
+    then
       acc
     else if
-      j >= Seq.length toks orelse
-      Source.absoluteStartOffset (Token.getSource (Seq.nth toks j)) > i
+      j >= Seq.length toks
+      orelse Source.absoluteStartOffset (Token.getSource (Seq.nth toks j)) > i
     then
       let
         val upper =
-          if j >= Seq.length toks then stop else
-          Int.min (stop,
-            Source.absoluteStartOffset (Token.getSource (Seq.nth toks j)))
-        val stuffUntilNextTok = Source.slice wholeSrc (i, upper-i)
-        val acc =
-          TCS.append (acc, TCS.fromString (Source.toString stuffUntilNextTok))
+          if j >= Seq.length toks then
+            stop
+          else
+            Int.min (stop, Source.absoluteStartOffset (Token.getSource
+              (Seq.nth toks j)))
+        val stuffUntilNextTok = Source.slice wholeSrc (i, upper - i)
+        val acc = TCS.append
+          (acc, TCS.fromString (Source.toString stuffUntilNextTok))
       in
         loop tokColor acc (wholeSrc, upper, stop) (toks, j)
       end
@@ -94,7 +87,8 @@ struct
         val thisOne = tokColor class (TCS.fromString (Source.toString thisSrc))
         val acc = TCS.append (acc, thisOne)
       in
-        loop tokColor acc (wholeSrc, Source.absoluteEndOffset thisSrc, stop) (toks, j+1)
+        loop tokColor acc (wholeSrc, Source.absoluteEndOffset thisSrc, stop)
+          (toks, j + 1)
       end
 
 
@@ -127,21 +121,17 @@ struct
           finish acc
         else
           ((case Lexer.next (Source.drop src offset) of
-            NONE =>
-              finish acc
-          | SOME tok =>
-              loop (tok :: acc) (tokEndOffset tok))
-          handle _ =>
-            loop acc (offset+1))
+              NONE => finish acc
+            | SOME tok => loop (tok :: acc) (tokEndOffset tok))
+           handle _ => loop acc (offset + 1))
 
       val result = loop [] startOffset
-
-(*
-      val _ = print ("fuzzyTokens\n")
-      val _ = print (Source.toString originalSrc ^ "\n")
-      val _ =
-        print ("Tokens: " ^ Seq.toString Token.toString result ^ "\n")
-*)
+        (*
+              val _ = print ("fuzzyTokens\n")
+              val _ = print (Source.toString originalSrc ^ "\n")
+              val _ =
+                print ("Tokens: " ^ Seq.toString Token.toString result ^ "\n")
+        *)
     in
       result
     end
@@ -153,8 +143,8 @@ struct
       val startOffset = Source.absoluteStartOffset source
       val endOffset = Source.absoluteEndOffset source
       val wholeSrc = Source.wholeFile source
-      val result =
-        loop tokColor TCS.empty (wholeSrc, startOffset, endOffset) (toks, 0)
+      val result = loop tokColor TCS.empty (wholeSrc, startOffset, endOffset)
+        (toks, 0)
     in
       (* print (TCS.debugShow result ^ "\n"); *)
       result


### PR DESCRIPTION
The formatter is good enough now that I feel confident running it on its own source code.

This patch is a "bite the bullet" kind of patch -- yes, it hits every file, which is annoying for git history. But in the long run I think it's important for `smlfmt` to be run on its own source, for demonstration purposes. This seems like the right time to start.