### PR TITLE
SuccessorML optional bar syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,9 @@ engine is the old version.
 
 `--debug-engine` enables debugging output, for developers. This flag requires
 that the `--preview-only` flag is also enabled.
+
+`-allow-top-level-exps [true|false]` (default `true`) controls whether or
+not top-level expressions (terminated by a semicolon) are allowed.
+
+`-allow-opt-bar [true|false]` (default `false`) controls whether or not
+SuccessorML optional bar syntax is allowed.

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -328,6 +328,9 @@ struct
         , off: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
         , delims: Token.t Seq.t (** the bars between match rules *)
+
+        (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+        , optbar: Token.t option
         }
 
     (** fn pat => exp [| pat => exp ...] *)

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -511,6 +511,8 @@ struct
             , elems: {vid: Token.t, arg: {off: Token.t, ty: Ty.t} option} Seq.t
             (** '|' delimiters between clauses *)
             , delims: Token.t Seq.t
+            (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+            , optbar: Token.t option
             } Seq.t
         (** 'and' delimiters between mutually recursive datatypes *)
         , delims: Token.t Seq.t

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -171,6 +171,9 @@ struct
               } Seq.t
           (** the `|` delimiters between bindings *)
           , delims: Token.t Seq.t
+
+          (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+          , optbar: Token.t option
           } Seq.t
 
       (** the `and` delimiters between bindings *)

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -303,6 +303,9 @@ struct
         , handlee: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
         , delims: Token.t Seq.t (** the bars between match rules *)
+
+        (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+        , optbar: Token.t option
         }
 
     (** raise exp *)

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -338,6 +338,9 @@ struct
         { fnn: Token.t
         , elems: {pat: Pat.t, arrow: Token.t, exp: exp} Seq.t
         , delims: Token.t Seq.t (** the bars between match rules *)
+
+        (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+        , optbar: Token.t option
         }
 
     (** things like _prim, _import, etc.

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -219,6 +219,9 @@ struct
 
           (** the `|` delimiters *)
           , delims: Token.t Seq.t
+
+          (** SuccessorML: optional leading bar (not permitted in Standard ML). *)
+          , optbar: Token.t option
           } Seq.t
 
       (** the `and` delimiters *)

--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2021 Sam Westrick
+(** Copyright (c) 2021-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -8,9 +8,14 @@ sig
   (** Take an .mlb source and fully parse all SML by loading all filepaths
     * recursively specified by the .mlb and parsing them, etc.
     *)
-  val parse: {pathmap: MLtonPathMap.t, skipBasis: bool, allowTopExp: bool}
-             -> FilePath.t
-             -> (FilePath.t * Parser.parser_output) Seq.t
+  val parse:
+    { pathmap: MLtonPathMap.t
+    , skipBasis: bool
+    , allowTopExp: bool
+    , allowOptBar: bool
+    }
+    -> FilePath.t
+    -> (FilePath.t * Parser.parser_output) Seq.t
 end =
 struct
 
@@ -65,7 +70,7 @@ struct
     TextIO.output (TextIO.stdErr, m)
 
   (** when skipBasis = true, we ignore paths containing $(SML_LIB) *)
-  fun parse {skipBasis, pathmap, allowTopExp} mlbPath :
+  fun parse {skipBasis, pathmap, allowTopExp, allowOptBar} mlbPath :
     (FilePath.t * Parser.parser_output) Seq.t =
     let
       open MLBAst
@@ -117,7 +122,8 @@ struct
                         handle OS.SysErr (msg, _) => errFun msg
 
               val (infdict, ast) =
-                Parser.parseWithInfdict {allowTopExp = allowTopExp}
+                Parser.parseWithInfdict
+                  {allowTopExp = allowTopExp, allowOptBar = allowOptBar}
                   (#fixities basis) src
             in
               ({fixities = infdict}, [(path, ast)])

--- a/src/parse/FixExpPrecedence.sml
+++ b/src/parse/FixExpPrecedence.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse/FixExpPrecedence.sml
+++ b/src/parse/FixExpPrecedence.sml
@@ -103,11 +103,16 @@ struct
               }
           end
 
-      | Handle {exp, handlee, elems, delims} =>
+      | Handle {exp, handlee, elems, delims, optbar} =>
           let
             fun leftReplaceWith e =
               Handle
-                {exp = e, handlee = handlee, elems = elems, delims = delims}
+                { exp = e
+                , handlee = handlee
+                , elems = elems
+                , delims = delims
+                , optbar = optbar
+                }
           in
             F { prec = 7
               , left = SOME {exp = exp, replaceWith = leftReplaceWith}

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -134,27 +134,6 @@ struct
   (** ========================================================================
     *)
 
-  fun checkOptBar allowOptBar optbar msg =
-    case optbar of
-      NONE => ()
-    | SOME bar =>
-        if allowOptBar then
-          ()
-        else
-          ParserUtils.error
-            { pos = Token.getSource bar
-            , what = msg
-            , explain =
-                SOME
-                  "This is disallowed in Standard ML, but allowed in \
-                  \SuccessorML with \"optional bar\" syntax. To enable \
-                  \optional bar syntax, use the command-line argument \
-                  \'-allow-opt-bar true'."
-            }
-
-  (** ========================================================================
-    *)
-
 
   fun dec {forceExactlyOne, allowOptBar} toks (start, infdict) =
     let
@@ -263,7 +242,7 @@ struct
               val (i, eq) = parse_reserved Token.Equal i
               val (i, optbar) = parse_maybeReserved Token.Bar i
               val _ =
-                checkOptBar allowOptBar optbar
+                ParserUtils.checkOptBar allowOptBar optbar
                   "Unexpected bar on first branch of datatype declaration."
 
               val (i, {elems, delims}) =
@@ -491,7 +470,7 @@ struct
 
               val (i, optbar) = parse_maybeReserved Token.Bar i
               val _ =
-                checkOptBar allowOptBar optbar
+                ParserUtils.checkOptBar allowOptBar optbar
                   "Unexpected bar on first branch of 'fun'."
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved
@@ -1058,7 +1037,7 @@ struct
           val (i, off) = parse_reserved Token.Of i
           val (i, optbar) = parse_maybeReserved Token.Bar i
           val _ =
-            checkOptBar allowOptBar optbar
+            ParserUtils.checkOptBar allowOptBar optbar
               "Unexpected bar on first branch of 'case'."
 
           val (i, {elems, delims}) =
@@ -1099,7 +1078,7 @@ struct
           val fnn = tok (i - 1)
           val (i, optbar) = parse_maybeReserved Token.Bar i
           val _ =
-            checkOptBar allowOptBar optbar
+            ParserUtils.checkOptBar allowOptBar optbar
               "Unexpected bar on first branch of anonymous function."
 
           val (i, {elems, delims}) =
@@ -1182,7 +1161,7 @@ struct
           val handlee = tok (i - 1)
           val (i, optbar) = parse_maybeReserved Token.Bar i
           val _ =
-            checkOptBar allowOptBar optbar
+            ParserUtils.checkOptBar allowOptBar optbar
               "Unexpected bar on first branch of 'handle'."
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -261,6 +261,10 @@ struct
               val (i, tyvars) = parse_tyvars i
               val (i, tycon) = parse_vid i
               val (i, eq) = parse_reserved Token.Equal i
+              val (i, optbar) = parse_maybeReserved Token.Bar i
+              val _ =
+                checkOptBar allowOptBar optbar
+                  "Unexpected bar on first branch of datatype declaration."
 
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved
@@ -272,6 +276,7 @@ struct
                 , eq = eq
                 , elems = elems
                 , delims = delims
+                , optbar = optbar
                 }
               )
             end

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -1166,12 +1166,20 @@ struct
       and consume_expHandle infdict exp i =
         let
           val handlee = tok (i - 1)
+          val (i, optbar) = parse_maybeReserved Token.Bar i
+          val _ =
+            checkOptBar optbar "Unexpected bar on first branch of 'handle'."
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
               {parseElem = consume_matchElem infdict, delim = Token.Bar} i
 
           val result = Ast.Exp.Handle
-            {exp = exp, handlee = handlee, elems = elems, delims = delims}
+            { exp = exp
+            , handlee = handlee
+            , elems = elems
+            , delims = delims
+            , optbar = optbar
+            }
 
           val result = FixExpPrecedence.maybeRotateLeft result
         in

--- a/src/parse/ParseSigExpAndSpec.sml
+++ b/src/parse/ParseSigExpAndSpec.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2021 Sam Westrick
+(** Copyright (c) 2021-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -85,9 +85,9 @@ struct
         PC.oneOrMoreWhile c p s
 
       fun consume_sigExp infdict i =
-        ParseSigExpAndSpec.sigexp toks infdict i
+        ParseSigExpAndSpec.sigexp {allowOptBar = allowOptBar} toks infdict i
       fun consume_sigSpec infdict i =
-        ParseSigExpAndSpec.spec toks infdict i
+        ParseSigExpAndSpec.spec {allowOptBar = allowOptBar} toks infdict i
 
 
       (** signature sigid = sigexp [and ...]

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2022 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse/ParserUtils.sml
+++ b/src/parse/ParserUtils.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/parse/ParserUtils.sml
+++ b/src/parse/ParserUtils.sml
@@ -12,6 +12,8 @@ sig
 
   val errorIfInfixNotOpped: InfixDict.t -> Token.t option -> Token.t -> unit
 
+  val checkOptBar: bool -> Token.t option -> string -> unit
+
   val nyi: Token.t Seq.t -> string -> int -> 'a
 end =
 struct
@@ -66,6 +68,25 @@ struct
            })
     else
       raise Fail ("Bug in parser " ^ fname ^ ": position out of bounds??")
+
+
+  fun checkOptBar allowOptBar optbar msg =
+    case optbar of
+      NONE => ()
+    | SOME bar =>
+        if allowOptBar then
+          ()
+        else
+          error
+            { pos = Token.getSource bar
+            , what = msg
+            , explain =
+                SOME
+                  "This is disallowed in Standard ML, but allowed in \
+                  \SuccessorML with \"optional bar\" syntax. To enable \
+                  \optional bar syntax, use the command-line argument \
+                  \'-allow-opt-bar true'."
+            }
 
 
 end

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -325,7 +325,7 @@ struct
                 (delims, Seq.drop elems 1)))
             end)
 
-      | Case {casee, exp = expTop, off, elems, delims} =>
+      | Case {casee, exp = expTop, off, elems, delims, optbar} =>
           let
             fun showBranch inner1 {pat, arrow, exp} =
               withNewChild showPat inner1 pat ++ token arrow
@@ -349,7 +349,7 @@ struct
                 cond inner2
                   {inactive = token off, active = at inner1 (token off)}
                 ++
-                Seq.iterate op++ (mk inner1 (NONE, Seq.nth elems 0))
+                Seq.iterate op++ (mk inner1 (optbar, Seq.nth elems 0))
                   (Seq.zipWith (mk inner1)
                      (Seq.map SOME delims, Seq.drop elems 1))))
           end

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -376,8 +376,8 @@ struct
                token raisee ++ newTab tab (fn inner => at inner (token id))
                ++ withNewChild showExp tab exp')
 
-      | Handle (args as {exp = expLeft, handlee, elems, delims}) =>
-          if Seq.length elems > 1 then
+      | Handle (args as {exp = expLeft, handlee, elems, delims, optbar}) =>
+          if Seq.length elems > 1 orelse Option.isSome optbar then
             showHandle tab args
           else
             newTab tab (fn inner =>
@@ -557,7 +557,7 @@ struct
     end
 
 
-  and showHandle tab {exp = expLeft, handlee, elems, delims} =
+  and showHandle tab {exp = expLeft, handlee, elems, delims, optbar} =
     newTabWithStyle tab (Tab.Style.allowComments, fn inner =>
       let
         fun showBranch {pat, arrow, exp} =
@@ -572,7 +572,7 @@ struct
       in
         at tab (showExp tab expLeft) ++ at tab (at inner (token handlee))
         ++
-        Seq.iterate op++ (mk (NONE, Seq.nth elems 0)) (Seq.zipWith mk
+        Seq.iterate op++ (mk (optbar, Seq.nth elems 0)) (Seq.zipWith mk
           (Seq.map SOME delims, Seq.drop elems 1))
       end)
 

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -316,18 +316,23 @@ struct
           newTab tab (fn inner => (* do we need the newTab here? *)
             let
               fun mk (delim, {pat, arrow, exp}) =
-                at inner
-                  ((case delim of
-                      NONE => empty
-                    | SOME d =>
-                        cond inner {inactive = empty, active = space} ++ token d)
-                   ++ withNewChild showPat inner pat ++ token arrow
-                   ++ withNewChild showExp inner exp)
+                let
+                  val stuff =
+                    withNewChild showPat inner pat ++ token arrow
+                    ++ withNewChild showExp inner exp
+                in
+                  case delim of
+                    NONE => stuff
+                  | SOME d =>
+                      at inner
+                        (cond inner {inactive = empty, active = space}
+                         ++ token d ++ stuff)
+                end
 
-              val initial = at inner (token fnn) ++ mk (optbar, Seq.nth elems 0)
+              val initial = token fnn ++ mk (optbar, Seq.nth elems 0)
             in
-              Seq.iterate op++ initial (Seq.zipWith mk
-                (Seq.map SOME delims, Seq.drop elems 1))
+              at inner (Seq.iterate op++ initial (Seq.zipWith mk
+                (Seq.map SOME delims, Seq.drop elems 1)))
             end)
 
       | Case {casee, exp = expTop, off, elems, delims, optbar} =>

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -910,11 +910,13 @@ struct
             at clauseTab (front ++ afterFront clauseTab clauseChildStyleRest)
         end
 
-      fun mkFunction (starter, {elems = innerElems, delims}) =
+      fun mkFunction (starter, {elems = innerElems, delims, optbar}) =
         let
           val clauseChildStyleFirst =
-            if Seq.length innerElems <= 1 then Tab.Style.inplace
-            else indentedAtLeastBy 6
+            if Seq.length innerElems <= 1 andalso not (Option.isSome optbar) then
+              Tab.Style.inplace
+            else
+              indentedAtLeastBy 6
 
           val clauseChildStyleRest = indentedAtLeastBy 4
 
@@ -932,10 +934,19 @@ struct
                   showClause mainTab clauseTab clauseChildStyleFirst
                     clauseChildStyleRest
               in
-                Seq.iterate op++
-                  (showClause' true (starter, Seq.nth innerElems 0))
-                  (Seq.zipWith (showClause' false)
-                     (Seq.map token delims, Seq.drop innerElems 1))
+                case optbar of
+                  NONE =>
+                    Seq.iterate op++
+                      (showClause' true (starter, Seq.nth innerElems 0))
+                      (Seq.zipWith (showClause' false)
+                         (Seq.map token delims, Seq.drop innerElems 1))
+                | SOME bar =>
+                    at mainTab starter
+                    ++
+                    Seq.iterate op++ empty (Seq.zipWith (showClause' false)
+                      ( Seq.map token (Seq.append (Seq.singleton bar, delims))
+                      , innerElems
+                      ))
               end)))
         end
 

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -211,7 +211,7 @@ struct
                   ++ withNewChildWithStyle (indentedAtLeastBy 4) showTy tab ty)
                arg)
 
-        fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
+        fun showOne (starter, {tyvars, tycon, eq, elems, delims, optbar}) =
           let
             val initial = at tab
               (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon
@@ -219,10 +219,15 @@ struct
 
             val skipper = cond tab {inactive = empty, active = space ++ space}
             fun dd delim = token delim ++ space
+
+            val firstConFront =
+              case optbar of
+                NONE => skipper
+              | SOME bar => dd bar
           in
             initial
             ++
-            Seq.iterate op++ (showCon (skipper, Seq.nth elems 0))
+            Seq.iterate op++ (showCon (firstConFront, Seq.nth elems 0))
               (Seq.zipWith showCon (Seq.map dd delims, Seq.drop elems 1))
           end
       in

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -38,7 +38,7 @@ struct
                   ++ withNewChildWithStyle (indentedAtLeastBy 4) showTy tab ty)
                arg)
 
-        fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
+        fun showOne (starter, {tyvars, tycon, eq, elems, delims, optbar}) =
           let
             val initial = at tab
               (token starter ++ showTokenSyntaxSeq tab tyvars ++ token tycon
@@ -46,10 +46,15 @@ struct
 
             val skipper = cond tab {inactive = empty, active = space ++ space}
             fun dd delim = token delim ++ space
+
+            val firstConFront =
+              case optbar of
+                NONE => skipper
+              | SOME bar => dd bar
           in
             initial
             ++
-            Seq.iterate op++ (showCon (skipper, Seq.nth elems 0))
+            Seq.iterate op++ (showCon (firstConFront, Seq.nth elems 0))
               (Seq.zipWith showCon (Seq.map dd delims, Seq.drop elems 1))
           end
       in

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2022 Sam Westrick
+(** Copyright (c) 2022-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -295,6 +295,13 @@ struct
   and showExp exp =
     let
       open Ast.Exp
+
+      fun optBarFail () =
+        raise Fail
+          "unsupported: SuccessorML optional bar syntax. Note: you are \
+          \using `-engine pretty`, which is headed towards \
+          \deprecation. Please use `-engine prettier` instead, \
+          \which supports optional bar syntax."
     in
       case exp of
         Const tok => token tok
@@ -357,12 +364,7 @@ struct
                (Seq.map mk (Seq.zip (delims, Seq.drop elems 1))))
           end
 
-      | Case {optbar = SOME _, ...} =>
-          raise Fail
-            "unsupported: SuccessorML optional bar syntax. Note: you are \
-            \using `-engine pretty`, which is headed towards \
-            \deprecation. Please use `-engine prettier` instead, \
-            \which supports optional bar syntax."
+      | Case {optbar = SOME _, ...} => optBarFail ()
 
       | Case {casee, exp = expTop, off, elems, delims, optbar = NONE} =>
           let
@@ -378,7 +380,9 @@ struct
                  (Seq.map mk (Seq.zip (delims, Seq.drop elems 1))))
           end
 
-      | Fn {fnn, elems, delims} =>
+      | Fn {optbar = SOME _, ...} => optBarFail ()
+
+      | Fn {fnn, elems, delims, optbar = NONE} =>
           let
             fun mk (delim, {pat, arrow, exp}) =
               space

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -23,13 +23,6 @@ struct
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat
 
-  fun optBarFail () =
-    raise Fail
-      "unsupported: SuccessorML optional bar syntax. Note: you are \
-      \using `-engine pretty`, which is headed towards \
-      \deprecation. Please use `-engine prettier` instead, \
-      \which supports optional bar syntax."
-
   fun showTypbind (front, typbind: Ast.Exp.typbind as {elems, delims}) =
     let
       fun showOne (starter, {tyvars, tycon, ty, eq}) =

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -357,7 +357,14 @@ struct
                (Seq.map mk (Seq.zip (delims, Seq.drop elems 1))))
           end
 
-      | Case {casee, exp = expTop, off, elems, delims} =>
+      | Case {optbar = SOME _, ...} =>
+          raise Fail
+            "unsupported: SuccessorML optional bar syntax. Note: you are \
+            \using `-engine pretty`, which is headed towards \
+            \deprecation. Please use `-engine prettier` instead, \
+            \which supports optional bar syntax."
+
+      | Case {casee, exp = expTop, off, elems, delims, optbar = NONE} =>
           let
             fun showBranch {pat, arrow, exp} =
               showPat pat ++ space ++ token arrow \\ showExp exp

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -23,6 +23,13 @@ struct
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat
 
+  fun optBarFail () =
+    raise Fail
+      "unsupported: SuccessorML optional bar syntax. Note: you are \
+      \using `-engine pretty`, which is headed towards \
+      \deprecation. Please use `-engine prettier` instead, \
+      \which supports optional bar syntax."
+
   fun showTypbind (front, typbind: Ast.Exp.typbind as {elems, delims}) =
     let
       fun showOne (starter, {tyvars, tycon, ty, eq}) =
@@ -49,8 +56,10 @@ struct
           , Option.map (fn {off, ty} => token off \\ showTy ty) arg
           ])
 
-      fun showOne (starter, {tyvars, tycon, eq, elems, delims}) =
+      fun showOne (starter, {tyvars, tycon, eq, elems, delims, optbar}) =
         let
+          val _ = if Option.isSome optbar then optBarFail () else ()
+
           val initial = group (separateWithSpaces
             [ SOME (token starter)
             , maybeShowSyntaxSeq tyvars token
@@ -84,14 +93,6 @@ struct
       | Andalso {left, andalsoo, right} => SOME (left, andalsoo, right)
       | _ => NONE
     end
-
-
-  fun optBarFail () =
-    raise Fail
-      "unsupported: SuccessorML optional bar syntax. Note: you are \
-      \using `-engine pretty`, which is headed towards \
-      \deprecation. Please use `-engine prettier` instead, \
-      \which supports optional bar syntax."
 
 
   fun showDecFun {funn, tyvars, fvalbind = {elems, delims}} =

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -86,6 +86,14 @@ struct
     end
 
 
+  fun optBarFail () =
+    raise Fail
+      "unsupported: SuccessorML optional bar syntax. Note: you are \
+      \using `-engine pretty`, which is headed towards \
+      \deprecation. Please use `-engine prettier` instead, \
+      \which supports optional bar syntax."
+
+
   fun showDecFun {funn, tyvars, fvalbind = {elems, delims}} =
     let
       open Ast.Exp
@@ -126,8 +134,10 @@ struct
              , SOME (token eq)
              ] $$ indentExp (showExp exp))
 
-      fun mkFunction (starter, {elems = innerElems, delims}) =
+      fun mkFunction (starter, {elems = innerElems, delims, optbar}) =
         let
+          val _ = if Option.isSome optbar then optBarFail () else ()
+
           fun firstIndentExp x =
             spaces (if Seq.length innerElems = 1 then 0 else 4) ++ indent x
           fun restIndentExp x = spaces 2 ++ indent x
@@ -295,13 +305,6 @@ struct
   and showExp exp =
     let
       open Ast.Exp
-
-      fun optBarFail () =
-        raise Fail
-          "unsupported: SuccessorML optional bar syntax. Note: you are \
-          \using `-engine pretty`, which is headed towards \
-          \deprecation. Please use `-engine prettier` instead, \
-          \which supports optional bar syntax."
     in
       case exp of
         Const tok => token tok

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -349,7 +349,9 @@ struct
 
       | Raise {raisee, exp} => token raisee \\ showExp exp
 
-      | Handle {exp = expLeft, handlee, elems, delims} =>
+      | Handle {optbar = SOME _, ...} => optBarFail ()
+
+      | Handle {exp = expLeft, handlee, elems, delims, optbar = NONE} =>
           let
             fun showBranch {pat, arrow, exp} =
               showPat pat ++ space ++ token arrow \\ showExp exp

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -92,8 +92,10 @@ struct
               , Option.map (fn {off, ty} => token off $$ indent (showTy ty)) arg
               ])
 
-          fun show_datdesc (starter, {tyvars, tycon, eq, elems, delims}) =
+          fun show_datdesc (starter, {tyvars, tycon, eq, elems, delims, optbar}) =
             let
+              val _ = if Option.isSome optbar then optBarFail () else ()
+
               val initial = group (separateWithSpaces
                 [ SOME (token starter)
                 , maybeShowSyntaxSeq tyvars token

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -18,6 +18,13 @@ struct
   fun x \\ y =
     group (x $$ indent y)
 
+  fun optBarFail () =
+    raise Fail
+      "unsupported: SuccessorML optional bar syntax. Note: you are \
+      \using `-engine pretty`, which is headed towards \
+      \deprecation. Please use `-engine prettier` instead, \
+      \which supports optional bar syntax."
+
   fun seqWithSpaces elems f =
     if Seq.length elems = 0 then
       empty

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -44,6 +44,7 @@ val engine = CommandLineArgs.parseString "engine" "prettier"
 val inputfiles = CommandLineArgs.positional ()
 
 val allowTopExp = CommandLineArgs.parseBool "allow-top-level-exps" true
+val allowOptBar = CommandLineArgs.parseBool "allow-opt-bar" false
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
 val doHelp = CommandLineArgs.parseFlag "help"
@@ -187,8 +188,9 @@ fun doSML filepath =
   let
     val fp = FilePath.fromUnixPath filepath
     val source = Source.loadFromFile fp
-    val result = Parser.parse {allowTopExp = allowTopExp} source
-                 handle exn => handleLexOrParseError exn
+    val result =
+      Parser.parse {allowTopExp = allowTopExp, allowOptBar = allowOptBar} source
+      handle exn => handleLexOrParseError exn
   in
     doSMLAst (fp, result)
   end
@@ -199,7 +201,11 @@ fun doMLB filepath =
     val fp = FilePath.fromUnixPath filepath
     val asts =
       ParseAllSMLFromMLB.parse
-        {skipBasis = true, pathmap = pathmap, allowTopExp = allowTopExp} fp
+        { skipBasis = true
+        , pathmap = pathmap
+        , allowTopExp = allowTopExp
+        , allowOptBar = allowOptBar
+        } fp
       handle exn => handleLexOrParseError exn
   in
     Util.for (0, Seq.length asts) (fn i => doSMLAst (Seq.nth asts i))

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2021 Sam Westrick
+(** Copyright (c) 2021-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)
@@ -11,24 +11,43 @@ fun printErr m =
   TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
-  "  [--force]              overwrite files without interactive confirmation\n\
-  \  [--preview]            show formatted before writing to file\n\
-  \  [--preview-only]       show formatted output and skip file overwrite\n\
-  \                         (incompatible with --force)\n\
-  \  [-max-width W]         try to use at most <W> columns in each line\n\
-  \                         (default 80)\n\
-  \  [-ribbon-frac R]       controls how dense each line should be\n\
-  \                         (default 1.0; requires 0 < R <= 1)\n\
-  \  [-tab-width T]         parse input tab-stops as having width <T>\n\
-  \                         (default 4)\n\
-  \  [-indent-width I]      use <I> spaces for indentation in output\n\
-  \                         (default 2)\n\
-  \  [-mlb-path-var 'K V']  MLton-style path variable\n\
-  \  [-engine E]            Select a pretty printing engine.\n\
-  \                         Valid options are: prettier, pretty\n\
-  \                         (default 'prettier')\n\
-  \  [--debug-engine]       Enable debugging output (for devs)\n\
-  \  [--help]               print this message\n"
+  "  [--force]                  overwrite files without interactive confirmation\n\
+  \\n\
+  \  [--preview]                show formatted before writing to file\n\
+  \\n\
+  \  [--preview-only]           show formatted output and skip file overwrite\n\
+  \                             (incompatible with --force)\n\
+  \\n\
+  \  [-max-width W]             try to use at most <W> columns in each line\n\
+  \                             (default 80)\n\
+  \\n\
+  \  [-ribbon-frac R]           controls how dense each line should be\n\
+  \                             (default 1.0; requires 0 < R <= 1)\n\
+  \\n\
+  \  [-tab-width T]             parse input tab-stops as having width <T>\n\
+  \                             (default 4)\n\
+  \\n\
+  \  [-indent-width I]          use <I> spaces for indentation in output\n\
+  \                             (default 2)\n\
+  \\n\
+  \  [-mlb-path-var 'K V']      MLton-style path variable\n\
+  \\n\
+  \  [-engine E]                Select a pretty printing engine.\n\
+  \                             Valid options are: prettier, pretty\n\
+  \                             (default 'prettier')\n\
+  \\n\
+  \  [--debug-engine]           Enable debugging output (for devs)\n\
+  \\n\
+  \  [-allow-top-level-exps B]  Enable/disable top-level expressions.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'true')\n\
+  \\n\
+  \  [-allow-opt-bar B]         Enable/disable SuccessorML optional bar syntax.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'false')\n\
+  \\n\
+  \  [--help]                   print this message\n"
+
 
 fun usage () =
   "usage: smlfmt [ARGS] FILE ... FILE\n" ^ "Optional arguments:\n"


### PR DESCRIPTION
Progress on #47.

Command-line option `-allow-opt-bar true` enables SuccessorML optional bar syntax, for example:
```sml
signature X =
sig
  datatype ('a, 'b) either =
  | Left of 'a  (* in first branch of datatype spec *)
  | Right of 'b
end

datatype ('a, 'b) either =
| Left of 'a  (* in first branch of datatype declaration *)
| Right of 'b

fun 'a
  | foo ([]: 'a list) = 0  (* in first branch of 'fun' declaration *)
  | foo (x :: xs) =
      case xs of
      | [] => 1  (* in first branch of 'case' expression *)
      | _ => 1 + foo xs

val bar =
  fn
   | [] => true  (* in first branch of anonymous function *)
   | x :: xs => false

val x =
  foo ()
  handle
  | Subscript => ()  (* in first branch of 'handle' expression *)
  | Option => ()
  | other => raise other
```