### PR TITLE
Tweak bigness heuristic

### DIFF
--- a/src/base/Dict.sml
+++ b/src/base/Dict.sml
@@ -110,14 +110,10 @@ struct
   val unionWith = M.unionWith
   val intersectWith = M.intersectWith
 
-  fun insert d (k, v) =
-    M.insert (d, k, v)
-  fun lookup d k =
-    M.lookup (d, k)
-  fun find d k =
-    M.find (d, k)
-  fun contains d k =
-    M.inDomain (d, k)
+  fun insert d (k, v) = M.insert (d, k, v)
+  fun lookup d k = M.lookup (d, k)
+  fun find d k = M.find (d, k)
+  fun contains d k = M.inDomain (d, k)
 
   fun remove d k =
     #1 (M.remove (d, k))

--- a/src/base/DocVar.sml
+++ b/src/base/DocVar.sml
@@ -24,7 +24,6 @@ struct
   fun toString (DocVar {id}) =
     "[v" ^ Int.toString id ^ "]"
 
-  fun compare (DocVar {id = id1}, DocVar {id = id2}) =
-    Int.compare (id1, id2)
+  fun compare (DocVar {id = id1}, DocVar {id = id2}) = Int.compare (id1, id2)
 
 end

--- a/src/base/Error.sml
+++ b/src/base/Error.sml
@@ -51,8 +51,7 @@ struct
 
 
   infix 6 ^^
-  fun x ^^ y =
-    TCS.append (x, y)
+  fun x ^^ y = TCS.append (x, y)
   fun $ x = TCS.fromString x
 
   fun showElement highlighter desiredWidth e =

--- a/src/base/MLtonPathMap.sml
+++ b/src/base/MLtonPathMap.sml
@@ -77,8 +77,7 @@ struct
   fun tryExpandField (pathmap: pathmap) (field: string) =
     let
       val n = String.size field
-      fun c i =
-        String.sub (field, i)
+      fun c i = String.sub (field, i)
       fun slice (i, j) =
         String.substring (field, i, j - i)
 

--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -85,8 +85,7 @@ struct
   val newline = Newline
   val space = Space
   val text = Text
-  fun at t d =
-    At (t, d)
+  fun at t d = At (t, d)
 
   fun cond tab {inactive, active} =
     Cond {tab = tab, inactive = inactive, active = active}
@@ -97,8 +96,7 @@ struct
     | (_, Empty) => d1
     | _ => Concat (d1, d2)
 
-  fun newTab (tab, doc) =
-    NewTab {tab = tab, doc = doc}
+  fun newTab (tab, doc) = NewTab {tab = tab, doc = doc}
 
   (* ====================================================================== *)
 

--- a/src/base/Set.sml
+++ b/src/base/Set.sml
@@ -34,10 +34,8 @@ struct
   type set = unit D.t
   type t = set
 
-  fun insert s x =
-    D.insert s (x, ())
-  fun singleton x =
-    D.singleton (x, ())
+  fun insert s x = D.insert s (x, ())
+  fun singleton x = D.singleton (x, ())
   fun fromList xs =
     D.fromList (List.map (fn x => (x, ())) xs)
   fun union (s, t) =

--- a/src/base/Source.sml
+++ b/src/base/Source.sml
@@ -112,8 +112,7 @@ struct
     , newlineIdxs = newlineIdxs
     }
 
-  fun take s k =
-    slice s (0, k)
+  fun take s k = slice s (0, k)
   fun drop s k =
     slice s (k, length s - k)
 

--- a/src/base/Tab.sml
+++ b/src/base/Tab.sml
@@ -119,8 +119,8 @@ struct
         , allowsComments = false
         }
     val rigid = S {indent = Inplace, rigid = true, allowsComments = false}
-    val allowComments = S
-      {indent = Inplace, rigid = false, allowsComments = true}
+    val allowComments =
+      S {indent = Inplace, rigid = false, allowsComments = true}
 
     fun isRigid (S {rigid, ...}) = rigid
 

--- a/src/base/TerminalColorString.sml
+++ b/src/base/TerminalColorString.sml
@@ -159,8 +159,8 @@ struct
                     strip tabstop (i + 1)
                   else
                     let
-                      val newfront = CharVector.tabulate (tabstop - n, fn _ =>
-                        #" ")
+                      val newfront =
+                        CharVector.tabulate (tabstop - n, fn _ => #" ")
                     in
                       (newfront, count, i)
                     end

--- a/src/lex-mlb/MLBToken.sml
+++ b/src/lex-mlb/MLBToken.sml
@@ -63,8 +63,7 @@ struct
   type token = {idx: int, context: pretoken Seq.t}
   type t = token
 
-  fun make src class =
-    WithSource.make {value = class, source = src}
+  fun make src class = WithSource.make {value = class, source = src}
 
   fun reserved src rclass =
     WithSource.make {value = Reserved rclass, source = src}

--- a/src/lex/Lexer.sml
+++ b/src/lex/Lexer.sml
@@ -93,10 +93,9 @@ struct
           error
             { pos = slice (s, s + 1)
             , what = "Invalid character."
-            , explain =
-                SOME
-                  "Strings can only contain printable (visible or \
-                  \whitespace) ASCII characters."
+            , explain = SOME
+                "Strings can only contain printable (visible or \
+                \whitespace) ASCII characters."
             }
         else
           SOME (EndOfChar (s + 1))
@@ -145,10 +144,9 @@ struct
           error
             { pos = slice (s - 1, s)
             , what = "Invalid escape sequence"
-            , explain =
-                SOME
-                  "Three-digit escape sequences must look like \
-                  \\\DDD where D is a decimal digit."
+            , explain = SOME
+                "Three-digit escape sequences must look like \
+                \\\DDD where D is a decimal digit."
             }
 
 
@@ -167,10 +165,9 @@ struct
           error
             { pos = slice (s - 2, s - 1)
             , what = "Invalid escape sequence."
-            , explain =
-                SOME
-                  "Four-digit escape sequences must look like \
-                  \\\uXXXX where X is a hexadecimal digit."
+            , explain = SOME
+                "Four-digit escape sequences must look like \
+                \\\uXXXX where X is a hexadecimal digit."
             }
 
 
@@ -184,10 +181,9 @@ struct
           error
             { pos = slice (s - 2, s - 1)
             , what = "Invalid escape sequence."
-            , explain =
-                SOME
-                  "Control escape sequences should look like \\^C where C is \
-                  \one of the following characters: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+            , explain = SOME
+                "Control escape sequences should look like \\^C where C is \
+                \one of the following characters: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
             }
 
 
@@ -210,10 +206,9 @@ struct
           error
             { pos = slice (s, s + 1)
             , what = "Invalid format escape character."
-            , explain =
-                SOME
-                  "Formatting escape sequences have to be enclosed by backslashes\
-                  \ and should only contain whitespace characters."
+            , explain = SOME
+                "Formatting escape sequences have to be enclosed by backslashes\
+                \ and should only contain whitespace characters."
             }
 
 
@@ -232,8 +227,8 @@ struct
                         "Bug found in lexer! Please report on GitHub..."
                     , Error.Paragraph
                         "Lexer.advance_toEndOfString: could not find end of string:"
-                    , Error.SourceReference (slice
-                        (stringStart, stringStart + 1))
+                    , Error.SourceReference
+                        (slice (stringStart, stringStart + 1))
                     , Error.Paragraph "Got up to here:"
                     , Error.SourceReference (slice (s, s + 1))
                     ]
@@ -359,8 +354,8 @@ struct
               error
                 { pos = srcHere
                 , what = "Unexpected reserved symbol."
-                , explain =
-                    SOME "Reserved symbols cannot be used as identifiers."
+                , explain = SOME
+                    "Reserved symbols cannot be used as identifiers."
                 }
             else if not isQualified then
               success tok
@@ -385,8 +380,8 @@ struct
               error
                 { pos = srcHere
                 , what = "Unexpected reserved keyword."
-                , explain =
-                    SOME "Reserved keywords cannot be used as identifiers."
+                , explain = SOME
+                    "Reserved keywords cannot be used as identifiers."
                 }
             else if
               is #"." at s andalso startsPrime
@@ -420,8 +415,8 @@ struct
           error
             { pos = slice (s, s + 1)
             , what = "Unexpected character."
-            , explain =
-                SOME "Identifiers have to start with a letter or symbol."
+            , explain = SOME
+                "Identifiers have to start with a letter or symbol."
             }
 
 
@@ -497,9 +492,8 @@ struct
           error
             { pos = slice (constStart, s)
             , what = "Invalid real constant."
-            , explain =
-                SOME
-                  "After the dot, there needs to be at least one decimal digit."
+            , explain = SOME
+                "After the dot, there needs to be at least one decimal digit."
             }
 
 

--- a/src/lex/Token.sml
+++ b/src/lex/Token.sml
@@ -1,4 +1,4 @@
-(** Copyright (c) 2020-2021 Sam Westrick
+(** Copyright (c) 2020-2023 Sam Westrick
   *
   * See the file LICENSE for details.
   *)

--- a/src/lex/Token.sml
+++ b/src/lex/Token.sml
@@ -109,6 +109,8 @@ sig
     *)
   val lineDifference: token * token -> int
 
+  val spansMultipleLines: token -> bool
+
   val isReserved: token -> bool
   val isStringConstant: token -> bool
   val isComment: token -> bool
@@ -280,6 +282,14 @@ struct
         start2 - end1
       else
         raise Fail "Bug! lineDifference on tokens from different files"
+    end
+
+  fun spansMultipleLines tok =
+    let
+      val {line = lnStart, ...} = Source.absoluteStart (getSource tok)
+      val {line = lnEnd, ...} = Source.absoluteEnd (getSource tok)
+    in
+      lnEnd <> lnStart
     end
 
   fun toString tok =

--- a/src/parse-mlb/MLBParser.sml
+++ b/src/parse-mlb/MLBParser.sml
@@ -87,10 +87,9 @@ struct
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected structure identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 
@@ -101,10 +100,9 @@ struct
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected signature identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 
@@ -115,10 +113,9 @@ struct
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected functor identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 
@@ -129,10 +126,9 @@ struct
       ParserUtils.error
         { pos = MLBToken.getSource (Seq.nth toks i)
         , what = "Expected basis identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 

--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -44,8 +44,7 @@ struct
     * the previous basis infix is overridden.)
     *)
   type basis = {fixities: InfixDict.t}
-  fun newScope ({fixities}: basis) =
-    {fixities = InfixDict.newScope fixities}
+  fun newScope ({fixities}: basis) = {fixities = InfixDict.newScope fixities}
   fun popScope ({fixities}: basis) : {old: basis, popped: basis} =
     let val {old, popped} = InfixDict.popScope fixities
     in {old = {fixities = old}, popped = {fixities = popped}}
@@ -66,8 +65,7 @@ struct
 
   type mlb_cache = basis FilePathDict.t
 
-  fun printErr m =
-    TextIO.output (TextIO.stdErr, m)
+  fun printErr m = TextIO.output (TextIO.stdErr, m)
 
   (** when skipBasis = true, we ignore paths containing $(SML_LIB) *)
   fun parse {skipBasis, pathmap, allowTopExp, allowOptBar} mlbPath :
@@ -159,8 +157,8 @@ struct
                       , dir = FilePath.dirname path
                       }
 
-                    val (mlbCache, b, a) = doBasdec ctx'
-                      (mlbCache, emptyBasis, basdec)
+                    val (mlbCache, b, a) =
+                      doBasdec ctx' (mlbCache, emptyBasis, basdec)
                   in
                     (FilePathDict.insert mlbCache (path, b), b, a)
                   end
@@ -190,8 +188,8 @@ struct
             let
               fun doElem ((mlbCache, basis, asts), basdec) =
                 let
-                  val (mlbCache, basis', asts') = doBasdec ctx
-                    (mlbCache, basis, basdec)
+                  val (mlbCache, basis', asts') =
+                    doBasdec ctx (mlbCache, basis, basdec)
                 in
                   (mlbCache, basis', asts' @ asts)
                 end
@@ -203,8 +201,8 @@ struct
             let
               fun doElem ((mlbCache, basis, asts), {basexp, ...}) =
                 let
-                  val (mlbCache, basis', asts') = doBasexp ctx
-                    (mlbCache, basis, basexp)
+                  val (mlbCache, basis', asts') =
+                    doBasexp ctx (mlbCache, basis, basexp)
                 in
                   (mlbCache, basis', asts' @ asts)
                 end
@@ -218,11 +216,11 @@ struct
                 * effectively hides any exports of basdec1
                 *)
               val basis = newScope basis
-              val (mlbCache, basis, asts1) = doBasdec ctx
-                (mlbCache, basis, basdec1)
+              val (mlbCache, basis, asts1) =
+                doBasdec ctx (mlbCache, basis, basdec1)
               val basis = newScope basis
-              val (mlbCache, basis, asts2) = doBasdec ctx
-                (mlbCache, basis, basdec2)
+              val (mlbCache, basis, asts2) =
+                doBasdec ctx (mlbCache, basis, basdec2)
               val {old = basis, popped = newBasis} = popScope basis
               val {old = basis, ...} = popScope basis
             in
@@ -245,11 +243,11 @@ struct
                 * effectively hides any exports of basdec
                 *)
               val basis = newScope basis
-              val (mlbCache, basis, asts1) = doBasdec ctx
-                (mlbCache, basis, basdec)
+              val (mlbCache, basis, asts1) =
+                doBasdec ctx (mlbCache, basis, basdec)
               val basis = newScope basis
-              val (mlbCache, basis, asts2) = doBasexp ctx
-                (mlbCache, basis, basexp)
+              val (mlbCache, basis, asts2) =
+                doBasexp ctx (mlbCache, basis, basexp)
               val {old = basis, popped = newBasis} = popScope basis
               val {old = basis, ...} = popScope basis
             in
@@ -270,8 +268,9 @@ struct
 
       val initialBasis = if skipBasis then initialTopLevelBasis else emptyBasis
 
-      val (_, _, asts) = doMLB {parents = [], dir = FilePath.fromUnixPath "."}
-        (emptyCache, initialBasis, mlbPath, topLevelError)
+      val (_, _, asts) =
+        doMLB {parents = [], dir = FilePath.fromUnixPath "."}
+          (emptyCache, initialBasis, mlbPath, topLevelError)
     in
       Seq.fromRevList asts
     end

--- a/src/parse/FixExpPrecedence.sml
+++ b/src/parse/FixExpPrecedence.sml
@@ -68,8 +68,7 @@ struct
       case e of
         Typed {exp, colon, ty} =>
           let
-            fun leftReplaceWith e =
-              Typed {exp = e, colon = colon, ty = ty}
+            fun leftReplaceWith e = Typed {exp = e, colon = colon, ty = ty}
           in
             F { prec = 10
               , left = SOME {exp = exp, replaceWith = leftReplaceWith}
@@ -122,8 +121,7 @@ struct
 
       | Raise {raisee, exp} =>
           let
-            fun replaceRightWith e =
-              Raise {raisee = raisee, exp = e}
+            fun replaceRightWith e = Raise {raisee = raisee, exp = e}
           in
             F { prec = 6
               , left = NONE

--- a/src/parse/InfixDict.sml
+++ b/src/parse/InfixDict.sml
@@ -77,9 +77,9 @@ struct
   fun newScope d = D.empty :: d
 
   fun popScope [_] = raise TopScope
-    | popScope (x :: d) =
-        {old = d, popped = [x]}
-    | popScope [] = raise Fail "Impossible! Bug in InfixDict"
+    | popScope (x :: d) = {old = d, popped = [x]}
+    | popScope [] =
+        raise Fail "Impossible! Bug in InfixDict"
 
   fun find d tok =
     let

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -64,10 +64,9 @@ struct
             ParserUtils.error
               { pos = Token.getSource rId
               , what = "Ambiguous infix expression."
-              , explain =
-                  SOME
-                    "You are not allowed to mix left- and right-associative \
-                    \operators of same precedence"
+              , explain = SOME
+                  "You are not allowed to mix left- and right-associative \
+                  \operators of same precedence"
               }
 
       | _ => default
@@ -88,8 +87,7 @@ struct
         Ast.Exp.DecInfix {precedence, elems, ...} =>
           let
             val p = parsePrec precedence
-            fun mk tok =
-              (tok, p, InfixDict.AssocLeft)
+            fun mk tok = (tok, p, InfixDict.AssocLeft)
           in
             Seq.iterate (fn (d, tok) => InfixDict.setInfix d (mk tok)) infdict
               elems
@@ -98,8 +96,7 @@ struct
       | Ast.Exp.DecInfixr {precedence, elems, ...} =>
           let
             val p = parsePrec precedence
-            fun mk tok =
-              (tok, p, InfixDict.AssocRight)
+            fun mk tok = (tok, p, InfixDict.AssocRight)
           in
             Seq.iterate (fn (d, tok) => InfixDict.setInfix d (mk tok)) infdict
               elems
@@ -241,9 +238,8 @@ struct
               val (i, tycon) = parse_vid i
               val (i, eq) = parse_reserved Token.Equal i
               val (i, optbar) = parse_maybeReserved Token.Bar i
-              val _ =
-                ParserUtils.checkOptBar allowOptBar optbar
-                  "Unexpected bar on first branch of datatype declaration."
+              val _ = ParserUtils.checkOptBar allowOptBar optbar
+                "Unexpected bar on first branch of datatype declaration."
 
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved
@@ -469,9 +465,8 @@ struct
                 end
 
               val (i, optbar) = parse_maybeReserved Token.Bar i
-              val _ =
-                ParserUtils.checkOptBar allowOptBar optbar
-                  "Unexpected bar on first branch of 'fun'."
+              val _ = ParserUtils.checkOptBar allowOptBar optbar
+                "Unexpected bar on first branch of 'fun'."
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved
                   {parseElem = parseBranch, delim = Token.Bar} i
@@ -771,8 +766,8 @@ struct
                 ParserUtils.tokError toks
                   { pos = i
                   , what = "Unexpected if-then-else expression."
-                  , explain =
-                      SOME "Try using parentheses: (if ... then ... else ...)"
+                  , explain = SOME
+                      "Try using parentheses: (if ... then ... else ...)"
                   }
 
             else if isReserved Token.Raise at i then
@@ -1036,9 +1031,8 @@ struct
           val (i, exp) = consume_exp infdict Restriction.None i
           val (i, off) = parse_reserved Token.Of i
           val (i, optbar) = parse_maybeReserved Token.Bar i
-          val _ =
-            ParserUtils.checkOptBar allowOptBar optbar
-              "Unexpected bar on first branch of 'case'."
+          val _ = ParserUtils.checkOptBar allowOptBar optbar
+            "Unexpected bar on first branch of 'case'."
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
@@ -1077,9 +1071,8 @@ struct
         let
           val fnn = tok (i - 1)
           val (i, optbar) = parse_maybeReserved Token.Bar i
-          val _ =
-            ParserUtils.checkOptBar allowOptBar optbar
-              "Unexpected bar on first branch of anonymous function."
+          val _ = ParserUtils.checkOptBar allowOptBar optbar
+            "Unexpected bar on first branch of anonymous function."
 
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
@@ -1160,9 +1153,8 @@ struct
         let
           val handlee = tok (i - 1)
           val (i, optbar) = parse_maybeReserved Token.Bar i
-          val _ =
-            ParserUtils.checkOptBar allowOptBar optbar
-              "Unexpected bar on first branch of 'handle'."
+          val _ = ParserUtils.checkOptBar allowOptBar optbar
+            "Unexpected bar on first branch of 'handle'."
           val (i, {elems, delims}) =
             parse_oneOrMoreDelimitedByReserved
               {parseElem = consume_matchElem infdict, delim = Token.Bar} i

--- a/src/parse/ParsePat.sml
+++ b/src/parse/ParsePat.sml
@@ -50,10 +50,9 @@ struct
             ParserUtils.error
               { pos = Token.getSource rId
               , what = "Ambiguous infix pattern."
-              , explain =
-                  SOME
-                    "You are not allowed to mix left- and right-associative \
-                    \operators of same precedence"
+              , explain = SOME
+                  "You are not allowed to mix left- and right-associative \
+                  \operators of same precedence"
               }
 
       | _ => default

--- a/src/parse/ParseSigExpAndSpec.sml
+++ b/src/parse/ParseSigExpAndSpec.sml
@@ -198,9 +198,8 @@ struct
               val (i, tycon) = parse_vid i
               val (i, eq) = parse_reserved Token.Equal i
               val (i, optbar) = parse_maybeReserved Token.Bar i
-              val _ =
-                ParserUtils.checkOptBar allowOptBar optbar
-                  "Unexpected bar on first branch of datatype specification."
+              val _ = ParserUtils.checkOptBar allowOptBar optbar
+                "Unexpected bar on first branch of datatype specification."
 
               val (i, {elems, delims}) =
                 parse_oneOrMoreDelimitedByReserved

--- a/src/parse/ParseSimple.sml
+++ b/src/parse/ParseSimple.sml
@@ -78,10 +78,9 @@ struct
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected structure identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 
@@ -92,10 +91,9 @@ struct
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected signature identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 
@@ -106,10 +104,9 @@ struct
       ParserUtils.tokError toks
         { pos = i
         , what = "Expected functor identifier."
-        , explain =
-            SOME
-              "Must be alphanumeric, and cannot start with a\
-              \ prime (')"
+        , explain = SOME
+            "Must be alphanumeric, and cannot start with a\
+            \ prime (')"
         }
 
 

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -110,8 +110,9 @@ struct
             parse_oneOrMoreDelimitedByReserved
               {parseElem = parseOne, delim = Token.And} i
 
-          val result: Ast.topdec = Ast.SigDec (Ast.Sig.Signature
-            {signaturee = signaturee, elems = elems, delims = delims})
+          val result: Ast.topdec = Ast.SigDec
+            (Ast.Sig.Signature
+               {signaturee = signaturee, elems = elems, delims = delims})
         in
           ((i, infdict), result)
         end
@@ -461,8 +462,9 @@ struct
               {parseElem = parseOne, delim = Token.And} i
         in
           ( (i, infdict)
-          , Ast.FunDec (Ast.Fun.DecFunctor
-              {functorr = functorr, elems = elems, delims = delims})
+          , Ast.FunDec
+              (Ast.Fun.DecFunctor
+                 {functorr = functorr, elems = elems, delims = delims})
           )
         end
 
@@ -565,11 +567,10 @@ struct
           ParserUtils.tokError toks
             { pos = i
             , what = "Unexpected token."
-            , explain =
-                SOME
-                  "Invalid start of top-level declaration. If you want to \
-                  \allow top-level expressions, use the command-line \
-                  \argument `-allow-top-level-exps true`."
+            , explain = SOME
+                "Invalid start of top-level declaration. If you want to \
+                \allow top-level expressions, use the command-line \
+                \argument `-allow-top-level-exps true`."
             }
 
       fun parse_topDecMaybeSemicolon (i, infdict) =

--- a/src/parse/ParserUtils.sml
+++ b/src/parse/ParserUtils.sml
@@ -80,12 +80,11 @@ struct
           error
             { pos = Token.getSource bar
             , what = msg
-            , explain =
-                SOME
-                  "This is disallowed in Standard ML, but allowed in \
-                  \SuccessorML with \"optional bar\" syntax. To enable \
-                  \optional bar syntax, use the command-line argument \
-                  \'-allow-opt-bar true'."
+            , explain = SOME
+                "This is disallowed in Standard ML, but allowed in \
+                \SuccessorML with \"optional bar\" syntax. To enable \
+                \optional bar syntax, use the command-line argument \
+                \'-allow-opt-bar true'."
             }
 
 

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -15,8 +15,7 @@ struct
   open PrettierTy
   open PrettierPat
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 
@@ -973,12 +972,13 @@ struct
 
           val clauseChildStyleRest = indentedAtLeastBy 4
 
-          val mainStyle = Tab.Style.combine
-            (rigidInplace, Tab.Style.allowComments)
+          val mainStyle =
+            Tab.Style.combine (rigidInplace, Tab.Style.allowComments)
 
-          val clauseStyle =
-            Tab.Style.combine (Tab.Style.allowComments, Tab.Style.combine
-              (Tab.Style.rigid, Tab.Style.indentedExactlyBy 2))
+          val clauseStyle = Tab.Style.combine
+            ( Tab.Style.allowComments
+            , Tab.Style.combine (Tab.Style.rigid, Tab.Style.indentedExactlyBy 2)
+            )
         in
           at tab (newTabWithStyle tab (mainStyle, fn mainTab =>
             newTabWithStyle mainTab (clauseStyle, fn clauseTab =>

--- a/src/prettier-print/PrettierFun.sml
+++ b/src/prettier-print/PrettierFun.sml
@@ -16,8 +16,7 @@ struct
   open PrettierStrUtil
   open PrettierStr
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ======================================================================= *)
 

--- a/src/prettier-print/PrettierPat.sml
+++ b/src/prettier-print/PrettierPat.sml
@@ -13,8 +13,7 @@ struct
   open PrettierUtil
   open PrettierTy
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -18,8 +18,7 @@ struct
   open PrettierStr
   open PrettierFun
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 
@@ -54,8 +53,9 @@ struct
 
   fun pretty (params as {ribbonFrac, maxWidth, tabWidth, indent, debug}) ast =
     let
-      val doc = showAst ast (* val doc = TokenDoc.insertComments doc
-                            val doc = TokenDoc.insertBlankLines doc *)
+      val doc =
+        showAst ast (* val doc = TokenDoc.insertComments doc
+                    val doc = TokenDoc.insertBlankLines doc *)
     in
       TabbedStringDoc.pretty
         { ribbonFrac = ribbonFrac

--- a/src/prettier-print/PrettierSig.sml
+++ b/src/prettier-print/PrettierSig.sml
@@ -17,8 +17,7 @@ struct
   open PrettierTy
   open PrettierSigUtil
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ======================================================================= *)
 

--- a/src/prettier-print/PrettierSigUtil.sml
+++ b/src/prettier-print/PrettierSigUtil.sml
@@ -14,8 +14,7 @@ struct
   open TabbedTokenDoc
   open PrettierUtil
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 

--- a/src/prettier-print/PrettierStr.sml
+++ b/src/prettier-print/PrettierStr.sml
@@ -18,8 +18,7 @@ struct
   open PrettierSig
   open PrettierStrUtil
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 

--- a/src/prettier-print/PrettierStrUtil.sml
+++ b/src/prettier-print/PrettierStrUtil.sml
@@ -20,8 +20,7 @@ struct
   open PrettierSigUtil
   open PrettierSig
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   (* ====================================================================== *)
 

--- a/src/prettier-print/PrettierTy.sml
+++ b/src/prettier-print/PrettierTy.sml
@@ -12,8 +12,7 @@ struct
   open TabbedTokenDoc
   open PrettierUtil
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
   fun showTy tab ty : doc =
     let

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -50,11 +50,10 @@ struct
 
   open TabbedTokenDoc
   infix 2 ++
-  fun x ++ y =
-    concat (x, y)
+  fun x ++ y = concat (x, y)
 
-  val indentedAllowComments = Tab.Style.combine
-    (Tab.Style.indented, Tab.Style.allowComments)
+  val indentedAllowComments =
+    Tab.Style.combine (Tab.Style.indented, Tab.Style.allowComments)
   val rigidInplace = Tab.Style.combine (Tab.Style.inplace, Tab.Style.rigid)
   val indented = Tab.Style.indented
   fun indentedAtLeastBy x = Tab.Style.indentedAtLeastBy x

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -66,8 +66,7 @@ struct
   val token = Token
   val text = Text
   val var = Var
-  fun at t d =
-    At (t, d)
+  fun at t d = At (t, d)
 
   fun concat (d1, d2) =
     case (d1, d2) of
@@ -113,8 +112,7 @@ struct
       NewTab {tab = t, doc = d}
     end
 
-  fun newTab parent f =
-    newTabWithStyle parent (Tab.Style.inplace, f)
+  fun newTab parent f = newTabWithStyle parent (Tab.Style.inplace, f)
 
   (* ====================================================================== *)
   (* ====================================================================== *)
@@ -309,8 +307,7 @@ struct
       datatype tab_constraint = Active | Inactive
       type context = tab_constraint TabDict.t
 
-      fun markInactive ctx tab =
-        TabDict.insert ctx (tab, Inactive)
+      fun markInactive ctx tab = TabDict.insert ctx (tab, Inactive)
 
       fun markActive ctx tab =
         case Tab.parent tab of
@@ -380,12 +377,12 @@ struct
              | SOME Inactive => loop ctx (flowval, vars, inactive)
              | _ =>
                  let
-                   val (flow1, vars, inactive) = loop (markInactive ctx tab)
-                     (flowval, vars, inactive)
-                   val (flow2, vars, active) = loop (markActive ctx tab)
-                     (flowval, vars, active)
-                   val flowval = (* TODO: is union necessary here? *) flowunion
-                     (flow1, flow2)
+                   val (flow1, vars, inactive) =
+                     loop (markInactive ctx tab) (flowval, vars, inactive)
+                   val (flow2, vars, active) =
+                     loop (markActive ctx tab) (flowval, vars, active)
+                   val flowval = (* TODO: is union necessary here? *)
+                     flowunion (flow1, flow2)
                  in
                    ( flowval
                    , vars
@@ -514,9 +511,8 @@ struct
                   (ht, cb, AnnAt {tab = tab, doc = doc}, ca)
                 else
                   let
-                    val all =
-                      Seq.map (fn d => AnnAt {tab = tab, doc = d}) (Seq.append3
-                        (cb, Seq.singleton doc, ca))
+                    val all = Seq.map (fn d => AnnAt {tab = tab, doc = d})
+                      (Seq.append3 (cb, Seq.singleton doc, ca))
                   in
                     (true, noComments, concatDocs all, noComments)
                   end
@@ -616,8 +612,7 @@ struct
                          * is only ever 'at' one possible tab...
                          *) List.hd (TabSet.listKeys tabs)
 
-                      fun withBreak d =
-                        AnnAt {tab = tab, doc = d}
+                      fun withBreak d = AnnAt {tab = tab, doc = d}
 
                       (* val all = Seq.append3 (cb, Seq.singleton doc, ca) *)
                       val all = Seq.append (cb, Seq.singleton doc)

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -15,10 +15,8 @@ struct
 
   infix 2 ++ $$ // +/+ +$+
   infix 1 \\
-  fun x +/+ y =
-    besideAndAbove (x, y)
-  fun x +$+ y =
-    besideAndAboveOrSpace (x, y)
+  fun x +/+ y = besideAndAbove (x, y)
+  fun x +$+ y = besideAndAboveOrSpace (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat

--- a/src/pretty-print/PrettyPat.sml
+++ b/src/pretty-print/PrettyPat.sml
@@ -13,12 +13,9 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ //
-  fun x ++ y =
-    beside (x, y)
-  fun x $$ y =
-    aboveOrSpace (x, y)
-  fun x // y =
-    aboveOrBeside (x, y)
+  fun x ++ y = beside (x, y)
+  fun x $$ y = aboveOrSpace (x, y)
+  fun x // y = aboveOrBeside (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
 

--- a/src/pretty-print/PrettyPrintAst.sml
+++ b/src/pretty-print/PrettyPrintAst.sml
@@ -17,12 +17,9 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ //
-  fun x ++ y =
-    beside (x, y)
-  fun x $$ y =
-    aboveOrSpace (x, y)
-  fun x // y =
-    aboveOrBeside (x, y)
+  fun x ++ y = beside (x, y)
+  fun x $$ y = aboveOrSpace (x, y)
+  fun x // y = aboveOrBeside (x, y)
 
   fun showTy ty = PrettyTy.showTy ty
   fun showPat pat = PrettyPat.showPat pat

--- a/src/pretty-print/PrettyTy.sml
+++ b/src/pretty-print/PrettyTy.sml
@@ -13,17 +13,12 @@ struct
   open PrettyUtil
 
   infix 2 ++ $$ // +/+ +$+
-  fun x ++ y =
-    beside (x, y)
-  fun x $$ y =
-    aboveOrSpace (x, y)
-  fun x // y =
-    aboveOrBeside (x, y)
+  fun x ++ y = beside (x, y)
+  fun x $$ y = aboveOrSpace (x, y)
+  fun x // y = aboveOrBeside (x, y)
 
-  fun x +/+ y =
-    besideAndAbove (x, y)
-  fun x +$+ y =
-    besideAndAboveOrSpace (x, y)
+  fun x +/+ y = besideAndAbove (x, y)
+  fun x +$+ y = besideAndAboveOrSpace (x, y)
 
   fun showTy ty =
     let

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -9,12 +9,9 @@ struct
   open TokenDoc
   infix 2 ++ $$ //
   infix 1 \\
-  fun x ++ y =
-    beside (x, y)
-  fun x $$ y =
-    aboveOrSpace (x, y)
-  fun x // y =
-    aboveOrBeside (x, y)
+  fun x ++ y = beside (x, y)
+  fun x $$ y = aboveOrSpace (x, y)
+  fun x // y = aboveOrBeside (x, y)
   fun x \\ y =
     group (x $$ indent y)
 

--- a/src/pretty-print/TokenDoc.sml
+++ b/src/pretty-print/TokenDoc.sml
@@ -192,8 +192,7 @@ struct
       fun finalize (doc, commBefore, commAfter) =
         aboveOrSpace (commBefore, aboveOrSpace (doc, commAfter))
 
-      fun modifyDoc g (ht, doc, cb, ca) =
-        (ht, g doc, cb, ca)
+      fun modifyDoc g (ht, doc, cb, ca) = (ht, g doc, cb, ca)
 
       fun combine bin (hasToks1, d1, cb1, ca1) (hasToks2, d2, cb2, ca2) =
         let

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -7,8 +7,7 @@ structure TCS = TerminalColorString
 structure TC = TerminalColors
 fun boldc c x =
   TCS.bold (TCS.foreground c (TCS.fromString x))
-fun printErr m =
-  TextIO.output (TextIO.stdErr, m)
+fun printErr m = TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
   "  [--force]                  overwrite files without interactive confirmation\n\
@@ -79,8 +78,8 @@ val _ =
 
 val _ =
   if previewOnly andalso doForce then
-    ( TCS.printErr
-        (boldc Palette.red "ERROR: --force incompatible with --preview-only\n")
+    ( TCS.printErr (boldc Palette.red
+        "ERROR: --force incompatible with --preview-only\n")
     ; OS.Process.exit OS.Process.failure
     )
   else
@@ -88,8 +87,8 @@ val _ =
 
 val _ =
   if doDebug andalso not (previewOnly) then
-    ( TCS.printErr
-        (boldc Palette.red "ERROR: --debug-engine requires --preview-only\n")
+    ( TCS.printErr (boldc Palette.red
+        "ERROR: --debug-engine requires --preview-only\n")
     ; OS.Process.exit OS.Process.failure
     )
   else

--- a/src/syntax-highlighting/SyntaxHighlighter.sml
+++ b/src/syntax-highlighting/SyntaxHighlighter.sml
@@ -143,8 +143,8 @@ struct
       val startOffset = Source.absoluteStartOffset source
       val endOffset = Source.absoluteEndOffset source
       val wholeSrc = Source.wholeFile source
-      val result = loop tokColor TCS.empty (wholeSrc, startOffset, endOffset)
-        (toks, 0)
+      val result =
+        loop tokColor TCS.empty (wholeSrc, startOffset, endOffset) (toks, 0)
     in
       (* print (TCS.debugShow result ^ "\n"); *)
       result


### PR DESCRIPTION
Bigness is used as a heuristic to determine where expressions can be split. This patch makes the bigness heuristic a bit more precise, resulting in nicer formatting in some cases. The two main changes are:
  * Large single tokens (e.g. multiline strings) are now identified as big.
  * Small tuples, records, etc. are now identified as **not** big.

As a demonstration, this patch includes reformatting within the repository from this change.