### PR TITLE
SuccessorML record punning syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,6 @@ not top-level expressions (terminated by a semicolon) are allowed.
 
 `-allow-opt-bar [true|false]` (default `false`) controls whether or not
 SuccessorML optional bar syntax is allowed.
+
+`-allow-record-pun-exps [true|false]` (default `false`) controls whether or not
+SuccessorML record punning syntax is allowed.

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -232,6 +232,11 @@ struct
       }
 
 
+    datatype 'exp row_exp =
+      RecordRow of {lab: Token.t, eq: Token.t, exp: 'exp}
+    | RecordPun of {id: Token.t}
+
+
     datatype exp =
       Const of Token.t
 
@@ -241,7 +246,7 @@ struct
     (** { lab = pat, ..., lab = pat } *)
     | Record of
         { left: Token.t
-        , elems: {lab: Token.t, eq: Token.t, exp: exp} Seq.t
+        , elems: exp row_exp Seq.t
         , delims: Token.t Seq.t (** Gotta remember the commas too! *)
         , right: Token.t
         }

--- a/src/parse-mlb/ParseAllSMLFromMLB.sml
+++ b/src/parse-mlb/ParseAllSMLFromMLB.sml
@@ -13,6 +13,7 @@ sig
     , skipBasis: bool
     , allowTopExp: bool
     , allowOptBar: bool
+    , allowRecordPun: bool
     }
     -> FilePath.t
     -> (FilePath.t * Parser.parser_output) Seq.t
@@ -68,8 +69,8 @@ struct
   fun printErr m = TextIO.output (TextIO.stdErr, m)
 
   (** when skipBasis = true, we ignore paths containing $(SML_LIB) *)
-  fun parse {skipBasis, pathmap, allowTopExp, allowOptBar} mlbPath :
-    (FilePath.t * Parser.parser_output) Seq.t =
+  fun parse {skipBasis, pathmap, allowTopExp, allowOptBar, allowRecordPun}
+    mlbPath : (FilePath.t * Parser.parser_output) Seq.t =
     let
       open MLBAst
 
@@ -121,8 +122,10 @@ struct
 
               val (infdict, ast) =
                 Parser.parseWithInfdict
-                  {allowTopExp = allowTopExp, allowOptBar = allowOptBar}
-                  (#fixities basis) src
+                  { allowTopExp = allowTopExp
+                  , allowOptBar = allowOptBar
+                  , allowRecordPun = allowRecordPun
+                  } (#fixities basis) src
             in
               ({fixities = infdict}, [(path, ast)])
             end

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -313,8 +313,11 @@ struct
           sequence left delims right (Seq.map showExp elems)
       | Record {left, elems, delims, right} =>
           let
-            fun showRow {lab, eq, exp} =
-              (token lab ++ space ++ token eq) \\ showExp exp
+            fun showRow row =
+              case row of
+                RecordPun _ => recordPunFail ()
+              | RecordRow {lab, eq, exp} =>
+                  (token lab ++ space ++ token eq) \\ showExp exp
           in
             sequence left delims right (Seq.map showRow elems)
           end

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -22,6 +22,13 @@ struct
       \deprecation. Please use `-engine prettier` instead, \
       \which supports optional bar syntax."
 
+  fun recordPunFail () =
+    raise Fail
+      "unsupported: SuccessorML record punning syntax. Note: you are \
+      \using `-engine pretty`, which is headed towards \
+      \deprecation. Please use `-engine prettier` instead, \
+      \which supports record punning."
+
   fun seqWithSpaces elems f =
     if Seq.length elems = 0 then
       empty

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -63,6 +63,7 @@ val inputfiles = CommandLineArgs.positional ()
 
 val allowTopExp = CommandLineArgs.parseBool "allow-top-level-exps" true
 val allowOptBar = CommandLineArgs.parseBool "allow-opt-bar" false
+val allowRecordPun = CommandLineArgs.parseBool "allow-record-pun-exps" false
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
 val doHelp = CommandLineArgs.parseFlag "help"
@@ -208,7 +209,11 @@ fun doSML filepath =
     val fp = FilePath.fromUnixPath filepath
     val source = Source.loadFromFile fp
     val result =
-      Parser.parse {allowTopExp = allowTopExp, allowOptBar = allowOptBar} source
+      Parser.parse
+        { allowTopExp = allowTopExp
+        , allowOptBar = allowOptBar
+        , allowRecordPun = allowRecordPun
+        } source
       handle exn => handleLexOrParseError exn
   in
     doSMLAst (fp, result)
@@ -224,6 +229,7 @@ fun doMLB filepath =
         , pathmap = pathmap
         , allowTopExp = allowTopExp
         , allowOptBar = allowOptBar
+        , allowRecordPun = allowRecordPun
         } fp
       handle exn => handleLexOrParseError exn
   in

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -45,6 +45,10 @@ val optionalArgDesc =
   \                             Valid options are: true, false\n\
   \                             (default 'false')\n\
   \\n\
+  \  [-allow-record-pun-exps B] Enable/disable SuccessorML record punning syntax.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'false')\n\
+  \\n\
   \  [--help]                   print this message\n"
 
 


### PR DESCRIPTION
Progress on #47.

Command-line option `-allow-record-pun-exps true` enables SuccessorML record punning syntax, for example:
```sml
val x = {foo, bar, baz = beez}
```