### PR TITLE
performance improvement: delayed `newTab` and `newTabWithStyle` to avoid unnecessary work

### DIFF
--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -52,7 +52,10 @@ struct
 
   fun pretty (params as {ribbonFrac, maxWidth, tabWidth, indent, debug}) ast =
     let
-      val doc = showAst ast
+      fun dbgprintln s =
+        if not debug then () else print (s ^ "\n")
+      val (doc, tm) = Util.getTime (fn _ => showAst ast)
+      val _ = dbgprintln ("to-doc: " ^ Time.fmt 3 tm ^ "s")
     (* val doc = TokenDoc.insertComments doc
     val doc = TokenDoc.insertBlankLines doc *)
     in

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -80,6 +80,9 @@ val preview = CommandLineArgs.parseFlag "preview"
 val previewOnly = CommandLineArgs.parseFlag "preview-only"
 val showPreview = preview orelse previewOnly
 
+fun dbgprintln s =
+  if not doDebug then () else print (s ^ "\n")
+
 val allows = AstAllows.make
   { topExp = allowTopExp
   , optBar = allowOptBar
@@ -223,9 +226,12 @@ fun doSMLAst (fp, parserOutput) =
 fun doSML filepath =
   let
     val fp = FilePath.fromUnixPath filepath
-    val source = Source.loadFromFile fp
-    val result = Parser.parse allows source
-                 handle exn => handleLexOrParseError exn
+    val (source, tm) = Util.getTime (fn _ => Source.loadFromFile fp)
+    val _ = dbgprintln ("load source: " ^ Time.fmt 3 tm ^ "s")
+    val (result, tm) = Util.getTime (fn _ =>
+      Parser.parse allows source
+      handle exn => handleLexOrParseError exn)
+    val _ = dbgprintln ("parse: " ^ Time.fmt 3 tm ^ "s")
   in
     doSMLAst (fp, result)
   end


### PR DESCRIPTION
The pretty printer is technically not linear cost relative to the size of the AST, because of the "splittable expressions" feature I added not too long ago (e.g. in #61).

This has a nasty impact on performance for certain files, and it's somewhat unpredictable -- it depends on how many splittable expressions there are, and also the "depth" of those expressions. If splittable expressions are nested within one another, the cost of the pretty printing algorithm can become exponential.

For example, here's a large input file (approximately 4000 lines) from the MLton repository: [`elaborate-core.fun`](https://github.com/MLton/mlton/blob/master/mlton/elaborate/elaborate-core.fun). On this file, `smlfmt` was taking 12 seconds to complete using 4.3 GB of memory (wow!)

## Solution

At first, I considered fixing this by either removing or adapting the "splittable expressions" thing, but I decided against it. Splittable expressions are really nice, and I don't see an easy way of avoiding the exponential algorithm.

So, here's a much simpler fix: use a thunk to delay the work of `newTab` and `newTabWithStyle`. This thunk is evaluated only if layout requires it. This requires surprisingly few changes to the source code. This is essentially the entire patch:
```diff
# in document ADT definition:

   | Text of CustomString.t
   | Token of Token.t
   | At of tab * doc
-  | NewTab of {tab: tab, doc: doc}
+  | NewTab of {tab: tab, gen: unit -> doc}
   | Cond of {tab: tab, inactive: doc, active: doc}
   | LetDoc of {var: DocVar.t, doc: doc, inn: doc}
   | Var of DocVar.t

# new tab creation:

   fun newTabWithStyle parent (style, genDocUsingTab: tab -> doc) =
     let
       val t = Tab.new {parent = parent, style = style}
-      val d = genDocUsingTab t
+      fun gen () = genDocUsingTab t
     in
-      NewTab {tab = t, doc = d}
+      NewTab {tab = t, gen = gen}
     end

# in layout algorithm:

-        | NewTab {tab, doc} =>
+        | NewTab {tab, gen} =>
             let
+              val doc = gen ()
+
               fun tryPromote () =
                 (* try to activate first *)
                 if not (isActivated tab) then
```

And, the results! (**Old** is before this patch, **New** is with this patch)

Input | Size (LoC) | Old Time | New Time | Old/New | Old MaxRSS | New MaxRSS | Old/New
-|-|-|-|-|-|-|-
`src/prettier-print/PrettierExpAndDec.sml` | 1024 | 170 ms | 60 ms | **2.8x** | 169 MB | 22 MB | **7.7x**
`src/base/PrettyTabbedDoc.sml` | 1342 | 60 ms | 60 ms | **1x** | 40 MB | 29 MB | **1.4x**
`src/parse/ParseExpAndDec.sml` | 1363 | 60 ms | 60 ms | **1x** | 30 MB | 22 MB | **1.4x**
MLton [`elaborate-core.fun`](https://github.com/MLton/mlton/blob/master/mlton/elaborate/elaborate-core.fun) | 3942 | 12 s | 220 ms | **54x** (!) | 4.2 GB | 100 MB | **42x** (!)