### PR TITLE
handle annotations in MLB `ann ... in ... end`

### DIFF
--- a/src/parse-mlb/ParseAnnotations.sml
+++ b/src/parse-mlb/ParseAnnotations.sml
@@ -1,0 +1,69 @@
+(** Copyright (c) 2023 Sam Westrick
+  *
+  * See the file LICENSE for details.
+  *)
+
+structure ParseAnnotations:
+sig
+  (* see DecAnn in MLBAst *)
+  type annotations = MLBToken.t Seq.t
+  val modifyAllows: AstAllows.t -> annotations -> AstAllows.t
+end =
+struct
+
+  type annotations = MLBToken.t Seq.t
+
+
+  fun allowOptBar a b =
+    AstAllows.make
+      { optBar = b
+      , topExp = AstAllows.topExp a
+      , recordPun = AstAllows.recordPun a
+      , orPat = AstAllows.orPat a
+      }
+
+
+  fun allowRecordPunExps a b =
+    AstAllows.make
+      { optBar = AstAllows.optBar a
+      , topExp = AstAllows.topExp a
+      , recordPun = b
+      , orPat = AstAllows.orPat a
+      }
+
+
+  fun allowOrPats a b =
+    AstAllows.make
+      { optBar = AstAllows.optBar a
+      , topExp = AstAllows.topExp a
+      , recordPun = AstAllows.recordPun a
+      , orPat = b
+      }
+
+
+  fun modifyOne (allows, ann) =
+    let
+      val src = MLBToken.getSource ann
+
+      (* this strips the initial and final `"` characters from the string *)
+      val str = CharVector.tabulate (Source.length src - 2, fn i =>
+        Source.nth src (i + 1))
+
+      (* val _ = print ("processing annotation: '" ^ str ^ "'\n") *)
+      val elems = String.tokens Char.isSpace str
+    in
+      case elems of
+        ["allowOptBar", "true"] => allowOptBar allows true
+      | ["allowOptBar", "false"] => allowOptBar allows false
+      | ["allowOrPats", "true"] => allowOrPats allows true
+      | ["allowOrPats", "false"] => allowOrPats allows false
+      | ["allowRecordPunExps", "true"] => allowRecordPunExps allows true
+      | ["allowRecordPunExps", "false"] => allowRecordPunExps allows false
+      | _ => allows
+    end
+
+
+  fun modifyAllows allows anns =
+    Seq.iterate modifyOne allows anns
+
+end

--- a/src/parse-mlb/sources.mlb
+++ b/src/parse-mlb/sources.mlb
@@ -4,4 +4,5 @@
 MLBAstType.sml
 MLBAst.sml
 MLBParser.sml
+ParseAnnotations.sml
 ParseAllSMLFromMLB.sml


### PR DESCRIPTION
MLB files allow for controlling SuccessorML language features, for example:
```
ann
  "allowOrPats true"
in
  foo.sml
end
```

Previously these were ignored. Now, we handle the following annotations:
  * `allowOrPats [true|false]`
  * `allowRecordPunExps [true|false]`
  * `allowOptBar [true|false]`

These are the current set of SuccessorML features that `smlfmt` supports. As additional SuccessorML features are added, we will extend the supported MLB annotations as well.

Note that default settings can still be controlled with `smlfmt` command-line options, for example `-allow-opt-bar true`. These default settings will be overridden by annotations within an MLB, similar to the behavior of MLton's `-default-ann ...`.