### PR TITLE
SuccessorML extended text constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ SuccessorML record punning syntax is allowed.
 
 `-allow-or-pats [true|false]` (default `false`) controls whether or not
 SuccessorML or-pattern syntax is allowed.
+
+`allow-extended-text-consts [true|false]` (default `false`) controls whether
+or not SuccessorML extended text constants are allowed. Enable this to allow
+for UTF-8 characters within strings.

--- a/src/ast/sources.mlb
+++ b/src/ast/sources.mlb
@@ -3,10 +3,8 @@ local
   MaybeLongToken.sml
   AstType.sml
   Ast.sml
-  AstAllows.sml
 in
   structure Token
   structure MaybeLongToken
   structure Ast
-  structure AstAllows
 end

--- a/src/base/AstAllows.sml
+++ b/src/base/AstAllows.sml
@@ -6,17 +6,36 @@
 structure AstAllows:
 sig
   type t
-  val make: {topExp: bool, optBar: bool, recordPun: bool, orPat: bool} -> t
+
+  val make:
+    { topExp: bool
+    , optBar: bool
+    , recordPun: bool
+    , orPat: bool
+    , extendedText: bool
+    }
+    -> t
+
   val topExp: t -> bool
   val optBar: t -> bool
   val recordPun: t -> bool
   val orPat: t -> bool
+  val extendedText: t -> bool
 end =
 struct
-  datatype t = T of {topExp: bool, optBar: bool, recordPun: bool, orPat: bool}
+  datatype t =
+    T of
+      { topExp: bool
+      , optBar: bool
+      , recordPun: bool
+      , orPat: bool
+      , extendedText: bool
+      }
+
   fun make x = T x
   fun topExp (T x) = #topExp x
   fun optBar (T x) = #optBar x
   fun recordPun (T x) = #recordPun x
   fun orPat (T x) = #orPat x
+  fun extendedText (T x) = #extendedText x
 end

--- a/src/base/sources.mlb
+++ b/src/base/sources.mlb
@@ -33,3 +33,5 @@ Tab.sml
 
 PrettySimpleDoc.sml
 PrettyTabbedDoc.sml
+
+AstAllows.sml

--- a/src/lex-mlb/MLBLexer.sml
+++ b/src/lex-mlb/MLBLexer.sml
@@ -26,14 +26,24 @@ struct
 
 
   fun expectSMLToken check src =
-    case Lexer.next src of
-      NONE => raise Fail "Lexer bug!"
-    | SOME ptok =>
-        (** TODO: some inefficiency here *)
-        if check (Token.fromPre ptok) then
-          success (MLBToken.Pretoken.fromSMLPretoken ptok)
-        else
-          raise Fail "Lexer bug!"
+    let
+      val smlLexerAllows = AstAllows.make
+        { topExp = false
+        , optBar = false
+        , recordPun = false
+        , orPat = false
+        , extendedText = false
+        }
+    in
+      case Lexer.next smlLexerAllows src of
+        NONE => raise Fail "Lexer bug!"
+      | SOME ptok =>
+          (** TODO: some inefficiency here *)
+          if check (Token.fromPre ptok) then
+            success (MLBToken.Pretoken.fromSMLPretoken ptok)
+          else
+            raise Fail "Lexer bug!"
+    end
 
 
   fun next (src: Source.t) : MLBToken.Pretoken.t option =

--- a/src/lex/Lexer.sml
+++ b/src/lex/Lexer.sml
@@ -117,10 +117,9 @@ struct
             { pos = slice (s, s + 1)
             , what = "Invalid character."
             , explain = SOME
-                "This might be a Unicode (UTF-8) byte. In Standard ML, this \
-                \byte is invalid because strings may only contain printable \
-                \ASCII characters. However, SuccessorML allows \
-                \for UTF-8 bytes. To enable this feature, \
+                "There might be a Unicode (UTF-8) byte here. In Standard ML, \
+                \strings may only contain printable ASCII characters. However, \
+                \SuccessorML allows for UTF-8. To enable this feature, \
                 \use the command-line argument \
                 \'-allow-extended-text-consts true'"
             }
@@ -133,8 +132,10 @@ struct
             { pos = slice (s, s + 1)
             , what = "Invalid character."
             , explain = SOME
-                "This byte is invalid because it is not a printable ASCII \
-                \character (visible or whitespace), and also because it does \
+                "There is an invalid byte here which may or may not be \
+                \visible. The \
+                \byte is invalid because it is not a printable ASCII \
+                \character, and also because it does \
                 \not appear to be UTF-8. \
                 \(UTF-8 bytes are allowed here due to either the \
                 \command-line argument '-allow-extended-text-consts true' or \
@@ -148,8 +149,9 @@ struct
             { pos = slice (s, s + 1)
             , what = "Invalid character."
             , explain = SOME
-                "This byte is invalid because it is not a printable character \
-                \(visible or whitespace)."
+                "There is an invalid byte here which may or may not be \
+                \visible. This byte is invalid because it is not a printable \
+                \character (visible or whitespace)."
             }
 
         else

--- a/src/parse-mlb/ParseAnnotations.sml
+++ b/src/parse-mlb/ParseAnnotations.sml
@@ -20,6 +20,7 @@ struct
       , topExp = AstAllows.topExp a
       , recordPun = AstAllows.recordPun a
       , orPat = AstAllows.orPat a
+      , extendedText = AstAllows.extendedText a
       }
 
 
@@ -29,6 +30,7 @@ struct
       , topExp = AstAllows.topExp a
       , recordPun = b
       , orPat = AstAllows.orPat a
+      , extendedText = AstAllows.extendedText a
       }
 
 
@@ -38,6 +40,17 @@ struct
       , topExp = AstAllows.topExp a
       , recordPun = AstAllows.recordPun a
       , orPat = b
+      , extendedText = AstAllows.extendedText a
+      }
+
+
+  fun allowExtendedTextConsts a b =
+    AstAllows.make
+      { optBar = AstAllows.optBar a
+      , topExp = AstAllows.topExp a
+      , recordPun = AstAllows.recordPun a
+      , orPat = AstAllows.orPat a
+      , extendedText = b
       }
 
 
@@ -59,6 +72,10 @@ struct
       | ["allowOrPats", "false"] => allowOrPats allows false
       | ["allowRecordPunExps", "true"] => allowRecordPunExps allows true
       | ["allowRecordPunExps", "false"] => allowRecordPunExps allows false
+      | ["allowExtendedTextConsts", "true"] =>
+          allowExtendedTextConsts allows true
+      | ["allowExtendedTextConsts", "false"] =>
+          allowExtendedTextConsts allows false
       | _ => allows
     end
 

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -35,7 +35,7 @@ struct
   fun parseWithInfdict allows infdict src =
     let
       (** This might raise Lexer.Error *)
-      val allTokens = Lexer.tokens src
+      val allTokens = Lexer.tokens allows src
       val toks = Seq.filter (not o Token.isCommentOrWhitespace) allTokens
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -73,6 +73,8 @@ val allowTopExp = CommandLineArgs.parseBool "allow-top-level-exps" true
 val allowOptBar = CommandLineArgs.parseBool "allow-opt-bar" false
 val allowRecordPun = CommandLineArgs.parseBool "allow-record-pun-exps" false
 val allowOrPat = CommandLineArgs.parseBool "allow-or-pats" false
+val allowExtendedText =
+  CommandLineArgs.parseBool "allow-extended-text-consts" false
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
 val doHelp = CommandLineArgs.parseFlag "help"
@@ -88,6 +90,7 @@ val allows = AstAllows.make
   , optBar = allowOptBar
   , recordPun = allowRecordPun
   , orPat = allowOrPat
+  , extendedText = allowExtendedText
   }
 
 val _ =

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -53,6 +53,13 @@ val optionalArgDesc =
   \                             Valid options are: true, false\n\
   \                             (default 'false')\n\
   \\n\
+  \  [-allow-extended-text-consts B]\n\
+  \                             Enable/disable SuccessorML extended text\n\
+  \                             constants. Enable this to allow for UTF-8\n\
+  \                             characters within strings.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'false')\n\
+  \\n\
   \  [--help]                   print this message\n"
 
 

--- a/src/syntax-highlighting/SyntaxHighlighter.sml
+++ b/src/syntax-highlighting/SyntaxHighlighter.sml
@@ -10,7 +10,7 @@ sig
   (** Use just lexing info to color a sequence of tokens from a single source.
     * Tokens must be in order as they appear in the source.
     *)
-  val highlight: Source.t -> TerminalColorString.t
+  val highlight: AstAllows.t -> Source.t -> TerminalColorString.t
 
   (** Similar to above, but always succeeds by skipping over characters as
     * necessary.
@@ -92,9 +92,9 @@ struct
       end
 
 
-  fun highlight source =
+  fun highlight allows source =
     let
-      val toks = Lexer.tokens source
+      val toks = Lexer.tokens allows source
       val startOffset = Source.absoluteStartOffset source
       val endOffset = Source.absoluteEndOffset source
       val wholeSrc = Source.wholeFile source
@@ -105,6 +105,14 @@ struct
 
   fun fuzzyTokens src =
     let
+      val smlLexerAllows = AstAllows.make
+        { topExp = true
+        , optBar = true
+        , recordPun = true
+        , orPat = true
+        , extendedText = true
+        }
+
       val originalSrc = src
       val startOffset = Source.absoluteStartOffset src
       val endOffset = Source.absoluteEndOffset src
@@ -120,7 +128,7 @@ struct
         if offset >= endOffset then
           finish acc
         else
-          ((case Lexer.next (Source.drop src offset) of
+          ((case Lexer.next smlLexerAllows (Source.drop src offset) of
               NONE => finish acc
             | SOME tok => loop (tok :: acc) (tokEndOffset tok))
            handle _ => loop acc (offset + 1))

--- a/test/succeed/extended-text.mlb
+++ b/test/succeed/extended-text.mlb
@@ -1,0 +1,4 @@
+$(SML_LIB)/basis/basis.mlb
+ann "allowExtendedTextConsts true" in
+  successor-ml/extended-text.sml
+end

--- a/test/succeed/successor-ml/extended-text.sml
+++ b/test/succeed/successor-ml/extended-text.sml
@@ -1,0 +1,2 @@
+val a = "🍰"
+val x = print "🂡\n"


### PR DESCRIPTION
Fixes #49 and additional progress on #47.

Command-line option `-allow-extended-text-consts true` allows for UTF-8 bytes within strings, for example:
```sml
val a = "🍰"
val x = print "🂡\n"
```

This can also be controlled from within an MLB following MLton conventions:
```
ann "allowExtendedTextConsts true" in
  foo.sml
end
```

Note that this feature does not check for validity of a UTF-8 byte sequence. We could add that later, if desired.