### PR TITLE
feat: Make `--stdio` the default for non-tty stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ to skip overwrite confirmations.
 $ ./smlfmt --force src/smlfmt.mlb
 ```
 
-To pass code through `stdin` and `stdout`, use the `--stdio` flag.
+Additionally, code can be passed directly through `stdin` and `stdout`.
 ```bash
-$ echo "val x = 5 val y = 6" | ./smlfmt --stdio
+$ echo "val x = 5 val y = 6" | ./smlfmt
 ```
+To force this behaviour, `--stdio` can be used.
 
 ### Command-line options
 
@@ -76,6 +77,8 @@ with syntax highlighting (if shown on terminal supporting ANSI colors).
 
 `--stdio` reads SML input from `stdin`, and outputs the formatted SML
 to `stdout`. (This is incompatible with file inputs and the flags above.)
+If no incompatible flag is set and `stdin` is not a terminal, this is
+the default.
 
 `-mlb-path-var '<key> <value>'` for handling path variables, similar to
 [MLton's path maps](http://mlton.org/MLBasisPathMap).

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -94,6 +94,15 @@ val doCheck = CommandLineArgs.parseFlag "check"
 val preview = CommandLineArgs.parseFlag "preview"
 val previewOnly = CommandLineArgs.parseFlag "preview-only"
 val stdio = CommandLineArgs.parseFlag "stdio"
+val stdio =
+  stdio
+  orelse
+  (* if stdin is not a terminal and an incompabible flag is not set, take input from stdin *)
+  (not (Posix.ProcEnv.isatty Posix.FileSys.stdin)
+   andalso
+   not
+     (doForce orelse preview orelse previewOnly
+      orelse not (List.null inputfiles)))
 val showPreview = preview orelse previewOnly
 
 fun dbgprintln s =


### PR DESCRIPTION
In the case where an incompatible flag is not set, `--stdio` will now be implied when standard input is not a terminal. This enables uses like
```bash
smlfmt < IN > OUT
```
without needing an additional flag.

The flag is currently left in, but I don't think it is necessary since users can simply do `cat | smlfmt` or similar if they'd really like to type over stdin at the terminal.

This isn't currently a breaking change since `--stdio` hasn't been included in a release yet, either any option (e.g., the one implemented here, or removing the explicit `--stdio` flag entirely) maintains backwards compatibility.

Another option would be to let `-` have specific meaning as an input file, designating stdin, which is common in Unix utilities, although this would presumably be a breaking change (currently this results in the usage text, so it might not be a big deal, but I'm not sure if it is cumbersome to implement with the current args parser).

I wasn't sure where changelog entries (if they do exist) should be put, so just let me know if there's a specific place/format and I can make one.

Closes #83.