### PR TITLE
feat(cli): add `read-only` flag

### DIFF
--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -11,6 +11,7 @@ fun printErr m = TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
   "  [--force]                  overwrite files without interactive confirmation\n\
+  \  [--unforce]                just parse files, without interactive confirmation\n\
   \\n\
   \  [--preview]                show formatted before writing to file\n\
   \\n\
@@ -85,6 +86,7 @@ val allowExtendedText =
 
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
+val doUnforce = CommandLineArgs.parseFlag "unforce"
 val doHelp = CommandLineArgs.parseFlag "help"
 val doCheck = CommandLineArgs.parseFlag "check"
 val preview = CommandLineArgs.parseFlag "preview"
@@ -259,13 +261,16 @@ fun formatOneSML
       end
 
     fun confirm () =
-      ( print ("overwrite " ^ hfp ^ " [y/N]? ")
-      ; case TextIO.inputLine TextIO.stdIn of
-          NONE => printErr ("skipping " ^ hfp ^ "\n")
-        | SOME line =>
-            if line = "y\n" orelse line = "Y\n" then writeOut ()
-            else printErr ("skipping " ^ hfp ^ "\n")
-      )
+      if doUnforce then
+        ()
+      else
+        ( print ("overwrite " ^ hfp ^ " [y/N]? ")
+        ; case TextIO.inputLine TextIO.stdIn of
+            NONE => printErr ("skipping " ^ hfp ^ "\n")
+          | SOME line =>
+              if line = "y\n" orelse line = "Y\n" then writeOut ()
+              else printErr ("skipping " ^ hfp ^ "\n")
+        )
   in
     if not showPreview then
       ()

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -11,12 +11,12 @@ fun printErr m = TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
   "  [--force]                  overwrite files without interactive confirmation\n\
-  \  [--unforce]                just parse files, without interactive confirmation\n\
   \\n\
   \  [--preview]                show formatted before writing to file\n\
   \\n\
   \  [--preview-only]           show formatted output and skip file overwrite\n\
   \                             (incompatible with --force)\n\
+  \  [--read-only]              just parse files, without interactive confirmation\n\
   \\n\
   \  [-max-width W]             try to use at most <W> columns in each line\n\
   \                             (default 80)\n\
@@ -86,7 +86,7 @@ val allowExtendedText =
 
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
-val doUnforce = CommandLineArgs.parseFlag "unforce"
+val doReadOnly = CommandLineArgs.parseFlag "read-only"
 val doHelp = CommandLineArgs.parseFlag "help"
 val doCheck = CommandLineArgs.parseFlag "check"
 val preview = CommandLineArgs.parseFlag "preview"
@@ -261,7 +261,7 @@ fun formatOneSML
       end
 
     fun confirm () =
-      if doUnforce then
+      if doReadOnly then
         ()
       else
         ( print ("overwrite " ^ hfp ^ " [y/N]? ")


### PR DESCRIPTION
## What:
This PR adds in a `--read-only` flag, which causes `smlfmt` to skip interactive confirmation in the negative sense, only parsing all files without previewing or formatting them. It's called `read-only`, because it just causes the files to be parsed/read, without overwriting or formatting.

## Why:
I'm interested in using `smlfmt` to detect syntax errors in code. I don't need the preview, since I just want the error output, so `--preview-only` isn't what I want.

## How:
Just added a command-line flag.

## Test plan:
This is what the flag does on my machine:
<img width="643" alt="image" src="https://github.com/shwestrick/smlfmt/assets/49291449/99e4894b-2705-4589-979f-135830f1ccc6">
 