### PR TITLE
Adjust heuristic for fun-decl body placement

### DIFF
--- a/src/ast/Ast.sml
+++ b/src/ast/Ast.sml
@@ -10,8 +10,7 @@ struct
 
   open AstType
 
-  fun join (Ast td1, Ast td2) =
-    Ast (Seq.append (td1, td2))
+  fun join (Ast td1, Ast td2) = Ast (Seq.append (td1, td2))
 
   val empty = Ast (Seq.empty ())
 

--- a/src/base/Dict.sml
+++ b/src/base/Dict.sml
@@ -115,12 +115,9 @@ struct
   fun find d k = M.find (d, k)
   fun contains d k = M.inDomain (d, k)
 
-  fun remove d k =
-    #1 (M.remove (d, k))
-    handle NotFound => d
+  fun remove d k = #1 (M.remove (d, k)) handle NotFound => d
 
-  fun fromList kvs =
-    List.foldl (fn ((k, v), d) => insert d (k, v)) empty kvs
+  fun fromList kvs = List.foldl (fn ((k, v), d) => insert d (k, v)) empty kvs
 
   val listKeys = M.listKeys
 

--- a/src/base/DocVar.sml
+++ b/src/base/DocVar.sml
@@ -16,13 +16,11 @@ struct
 
   val counter = ref 0
 
-  fun new () =
-    let val result = DocVar {id = !counter}
-    in counter := !counter + 1; result
-    end
+  fun new () = let val result = DocVar {id = !counter}
+               in counter := !counter + 1; result
+               end
 
-  fun toString (DocVar {id}) =
-    "[v" ^ Int.toString id ^ "]"
+  fun toString (DocVar {id}) = "[v" ^ Int.toString id ^ "]"
 
   fun compare (DocVar {id = id1}, DocVar {id = id2}) = Int.compare (id1, id2)
 

--- a/src/base/FilePath.sml
+++ b/src/base/FilePath.sml
@@ -69,8 +69,7 @@ struct
       List.rev (List.foldl addParent (basename fields) (dirname fields))
     end
 
-  fun sameFile (fp1, fp2) =
-    Util.equalLists op= (normalize fp1, normalize fp2)
+  fun sameFile (fp1, fp2) = Util.equalLists op= (normalize fp1, normalize fp2)
 
   fun join (fields1, fields2) = fields2 @ fields1
 
@@ -78,14 +77,12 @@ struct
     if String.size s = 0 then raise InvalidPathString s
     else List.rev (String.fields (fn c => c = #"/") s)
 
-  fun toUnixPath s =
-    String.concatWith "/" (List.rev s)
+  fun toUnixPath s = String.concatWith "/" (List.rev s)
 
   (** The first field of an (absolute) Unix path is always the empty string.
     * So look at the last, because we represent path fields in reverse order.
     *)
   fun isAbsolute path = List.last path = ""
 
-  fun toHostPath path =
-    OS.Path.fromUnixPath (toUnixPath path)
+  fun toHostPath path = OS.Path.fromUnixPath (toUnixPath path)
 end

--- a/src/base/MLtonPathMap.sml
+++ b/src/base/MLtonPathMap.sml
@@ -69,8 +69,7 @@ struct
     let
       val n = String.size field
       fun c i = String.sub (field, i)
-      fun slice (i, j) =
-        String.substring (field, i, j - i)
+      fun slice (i, j) = String.substring (field, i, j - i)
 
 
       fun findNextKeyStart (i: int) =
@@ -88,8 +87,7 @@ struct
         else findNextKeyEnd (i + 1)
 
 
-      fun finishLoop (usedKeys, acc) =
-        (usedKeys, String.concat (List.rev acc))
+      fun finishLoop (usedKeys, acc) = (usedKeys, String.concat (List.rev acc))
 
       (** Example:
         *   abc$(foo)def$(bar)...

--- a/src/base/MemoizedPromise.sml
+++ b/src/base/MemoizedPromise.sml
@@ -15,8 +15,7 @@ struct
 
   type 'a t = 'a contents ref
 
-  fun new f =
-    ref (Delayed f)
+  fun new f = ref (Delayed f)
 
   fun get m =
     case !m of

--- a/src/base/PrettyTabbedDoc.sml
+++ b/src/base/PrettyTabbedDoc.sml
@@ -173,8 +173,7 @@ struct
 
   fun firstToken doc =
     let
-      fun error () =
-        raise Fail "PrettyTabbedDoc.firstToken: disagreement"
+      fun error () = raise Fail "PrettyTabbedDoc.firstToken: disagreement"
 
       fun loop vars doc =
         case doc of
@@ -641,8 +640,7 @@ struct
     if n = 0 then d else addNewlines (n - 1) (Concat (Newline, d))
 
 
-  fun concatDocs ds =
-    Seq.iterate concat empty ds
+  fun concatDocs ds = Seq.iterate concat empty ds
 
 
   fun tokenToDoc {tabWidth} currentTab tok =
@@ -682,8 +680,7 @@ struct
   fun pretty {ribbonFrac, maxWidth, indentWidth, tabWidth, debug} doc =
     let
       val t0 = Time.now ()
-      fun dbgprintln s =
-        if not debug then () else print (s ^ "\n")
+      fun dbgprintln s = if not debug then () else print (s ^ "\n")
 
       val ribbonWidth = Int.max (0, Int.min (maxWidth, Real.round
         (ribbonFrac * Real.fromInt maxWidth)))
@@ -695,11 +692,9 @@ struct
 
       val tabstate = ref TabDict.empty
 
-      fun getTabState t =
-        TabDict.lookup (!tabstate) t
+      fun getTabState t = TabDict.lookup (!tabstate) t
 
-      fun setTabState t x =
-        tabstate := TabDict.insert (!tabstate) (t, x)
+      fun setTabState t x = tabstate := TabDict.insert (!tabstate) (t, x)
 
       val _ = setTabState Tab.root (Usable (Activated (SOME 0)))
 
@@ -1098,8 +1093,7 @@ struct
 
         | LetDoc {var, doc, inn} =>
             let
-              fun delayedLayout state =
-                layout vars state doc
+              fun delayedLayout state = layout vars state doc
               val vars = VarDict.insert vars (var, delayedLayout)
             in
               layout vars state inn

--- a/src/base/ReadFile.sml
+++ b/src/base/ReadFile.sml
@@ -49,11 +49,9 @@ struct
       ArraySlice.full result
     end
 
-  fun contentsSeq path =
-    contentsSeq' (Char.chr 0, Char.chr o Word8.toInt) path
+  fun contentsSeq path = contentsSeq' (Char.chr 0, Char.chr o Word8.toInt) path
 
-  fun contentsBinSeq path =
-    contentsSeq' (0w0, fn w => w) path
+  fun contentsBinSeq path = contentsSeq' (0w0, fn w => w) path
 
   fun contents filename =
     let

--- a/src/base/Seq.sml
+++ b/src/base/Seq.sml
@@ -55,18 +55,15 @@ struct
 
   fun nth s i = AS.sub (s, i)
 
-  fun empty () =
-    AS.full (A.fromList [])
-  fun singleton x =
-    AS.full (A.array (1, x))
+  fun empty () = AS.full (A.fromList [])
+  fun singleton x = AS.full (A.array (1, x))
   val $ = singleton
   fun toString f s =
     "<" ^ String.concatWith "," (List.tabulate (length s, f o nth s)) ^ ">"
 
   fun fromArray a = AS.full a
 
-  fun fromList l =
-    AS.full (A.fromList l)
+  fun fromList l = AS.full (A.fromList l)
   val % = fromList
   fun toList s =
     SeqBasis.foldl (fn (list, x) => x :: list) [] (0, length s) (fn i =>
@@ -90,23 +87,18 @@ struct
         end
 
 
-  fun empty () =
-    AS.full (Array.fromList [])
+  fun empty () = AS.full (Array.fromList [])
 
-  fun tabulate f n =
-    AS.full (Array.tabulate (n, f))
+  fun tabulate f n = AS.full (Array.tabulate (n, f))
 
-  fun map f s =
-    tabulate (f o nth s) (length s)
+  fun map f s = tabulate (f o nth s) (length s)
 
-  fun mapIdx f s =
-    tabulate (fn i => f (i, nth s i)) (length s)
+  fun mapIdx f s = tabulate (fn i => f (i, nth s i)) (length s)
 
   fun zipWith f (s, t) =
     tabulate (fn i => f (nth s i, nth t i)) (Int.min (length s, length t))
 
-  fun iterate f b s =
-    SeqBasis.foldl f b (0, length s) (nth s)
+  fun iterate f b s = SeqBasis.foldl f b (0, length s) (nth s)
 
   fun equal eq (s, t) =
     length s = length t
@@ -117,8 +109,7 @@ struct
   fun append (s, t) =
     let
       val (ns, nt) = (length s, length t)
-      fun ith i =
-        if i < ns then nth s i else nth t (i - ns)
+      fun ith i = if i < ns then nth s i else nth t (i - ns)
     in
       tabulate ith (ns + nt)
     end
@@ -134,25 +125,18 @@ struct
       tabulate ith (na + nb + nc)
     end
 
-  fun zip (s, t) =
-    zipWith (fn xx => xx) (s, t)
+  fun zip (s, t) = zipWith (fn xx => xx) (s, t)
 
-  fun rev s =
-    tabulate (fn i => nth s (length s - 1 - i)) (length s)
+  fun rev s = tabulate (fn i => nth s (length s - 1 - i)) (length s)
 
-  fun filter p s =
-    AS.full (SeqBasis.filter (0, length s) (nth s) (p o nth s))
+  fun filter p s = AS.full (SeqBasis.filter (0, length s) (nth s) (p o nth s))
 
-  fun applyIdx s f =
-    Util.for (0, length s) (fn i => f (i, nth s i))
+  fun applyIdx s f = Util.for (0, length s) (fn i => f (i, nth s i))
 
-  fun subseq s (i, k) =
-    AS.subslice (s, i, SOME k)
+  fun subseq s (i, k) = AS.subslice (s, i, SOME k)
   fun take s n = subseq s (0, n)
-  fun drop s n =
-    subseq s (n, length s - n)
+  fun drop s n = subseq s (n, length s - n)
   fun first s = nth s 0
-  fun last s =
-    nth s (length s - 1)
+  fun last s = nth s (length s - 1)
 
 end

--- a/src/base/Set.sml
+++ b/src/base/Set.sml
@@ -36,10 +36,7 @@ struct
 
   fun insert s x = D.insert s (x, ())
   fun singleton x = D.singleton (x, ())
-  fun fromList xs =
-    D.fromList (List.map (fn x => (x, ())) xs)
-  fun union (s, t) =
-    D.unionWith (fn _ => ()) (s, t)
-  fun intersect (s, t) =
-    D.intersectWith (fn _ => ()) (s, t)
+  fun fromList xs = D.fromList (List.map (fn x => (x, ())) xs)
+  fun union (s, t) = D.unionWith (fn _ => ()) (s, t)
+  fun intersect (s, t) = D.intersectWith (fn _ => ()) (s, t)
 end

--- a/src/base/Source.sml
+++ b/src/base/Source.sml
@@ -132,14 +132,11 @@ struct
     }
 
   fun take s k = slice s (0, k)
-  fun drop s k =
-    slice s (k, length s - k)
+  fun drop s k = slice s (k, length s - k)
 
-  fun absoluteEnd s =
-    absoluteStart (drop s (length s))
+  fun absoluteEnd s = absoluteStart (drop s (length s))
 
-  fun toString s =
-    CharVector.tabulate (length s, nth s)
+  fun toString s = CharVector.tabulate (length s, nth s)
 
   fun wholeFile ({data, fileName, newlineIdxs}: source) =
     let

--- a/src/base/Tab.sml
+++ b/src/base/Tab.sml
@@ -175,8 +175,7 @@ struct
       Root => "root"
     | Tab {id = c, ...} => Int.toString c
 
-  fun toString t =
-    "[" ^ name t ^ "]"
+  fun toString t = "[" ^ name t ^ "]"
 
   fun compare (t1: tab, t2: tab) : order =
     case (t1, t2) of
@@ -185,23 +184,17 @@ struct
     | (Tab _, Root) => GREATER
     | (Root, Tab _) => LESS
 
-  fun eq (t1, t2) =
-    compare (t1, t2) = EQUAL
+  fun eq (t1, t2) = compare (t1, t2) = EQUAL
 
   fun depth t =
     case t of
       Root => 0
     | Tab {parent = p, ...} => 1 + depth p
 
-  fun isRigid t =
-    Style.isRigid (style t)
-  fun isInplace t =
-    Style.isInplace (style t)
-  fun minIndent t =
-    Style.minIndent (style t)
-  fun maxIndent t =
-    Style.maxIndent (style t)
-  fun allowsComments t =
-    Style.allowsComments (style t)
+  fun isRigid t = Style.isRigid (style t)
+  fun isInplace t = Style.isInplace (style t)
+  fun minIndent t = Style.minIndent (style t)
+  fun maxIndent t = Style.maxIndent (style t)
+  fun allowsComments t = Style.allowsComments (style t)
 
 end

--- a/src/base/TerminalColorString.sml
+++ b/src/base/TerminalColorString.sml
@@ -72,8 +72,7 @@ struct
 
   val empty = Empty
 
-  fun fromChar c =
-    String (String.str c)
+  fun fromChar c = String (String.str c)
   fun fromString s = String s
 
   fun append (t1, t2) =
@@ -82,8 +81,7 @@ struct
     | (_, Empty) => t1
     | _ => Append {size = size t1 + size t2, left = t1, right = t2}
 
-  fun concat ts =
-    List.foldl (fn (next, prev) => append (prev, next)) Empty ts
+  fun concat ts = List.foldl (fn (next, prev) => append (prev, next)) Empty ts
 
   fun concatWith t ts =
     case ts of
@@ -247,15 +245,13 @@ struct
   fun backgroundIfNone color t =
     if hasNoBackground t then background color t else t
 
-  fun bold t =
-    let val (a, t) = splitAttributes t
-    in Attributes {size = size t, attr = setBold a, child = t}
-    end
+  fun bold t = let val (a, t) = splitAttributes t
+               in Attributes {size = size t, attr = setBold a, child = t}
+               end
 
-  fun italic t =
-    let val (a, t) = splitAttributes t
-    in Attributes {size = size t, attr = setItalic a, child = t}
-    end
+  fun italic t = let val (a, t) = splitAttributes t
+                 in Attributes {size = size t, attr = setItalic a, child = t}
+                 end
 
   fun underline t =
     let val (a, t) = splitAttributes t

--- a/src/base/TerminalColors.sml
+++ b/src/base/TerminalColors.sml
@@ -62,8 +62,7 @@ struct
       {red = R1 + m, green = G1 + m, blue = B1 + m}
     end
 
-  fun to256 channel =
-    Real.ceil (channel * 255.0)
+  fun to256 channel = Real.ceil (channel * 255.0)
 
   val esc = "\027["
 

--- a/src/base/TextFormat.sml
+++ b/src/base/TextFormat.sml
@@ -21,8 +21,7 @@ struct
 
   type width = int
 
-  fun repeatChar n c =
-    CharVector.tabulate (n, fn _ => c)
+  fun repeatChar n c = CharVector.tabulate (n, fn _ => c)
 
   fun leftPadWith char desiredWidth str =
     if String.size str >= desiredWidth then str
@@ -54,8 +53,7 @@ struct
 
   fun textWrap desiredWidth str =
     let
-      fun finishLine ln =
-        String.concatWith " " (List.rev ln)
+      fun finishLine ln = String.concatWith " " (List.rev ln)
       fun loop lines (currLine, currLen) toks =
         case toks of
           tok :: remaining =>

--- a/src/base/Util.sml
+++ b/src/base/Util.sml
@@ -38,22 +38,19 @@ struct
 
   fun all (lo, hi) f =
     let
-      fun allFrom i =
-        (i >= hi) orelse (f i andalso allFrom (i + 1))
+      fun allFrom i = (i >= hi) orelse (f i andalso allFrom (i + 1))
     in
       allFrom lo
     end
 
   fun exists (lo, hi) f =
     let
-      fun existsFrom i =
-        i < hi andalso (f i orelse existsFrom (i + 1))
+      fun existsFrom i = i < hi andalso (f i orelse existsFrom (i + 1))
     in
       existsFrom lo
     end
 
-  fun for (lo, hi) f =
-    if lo >= hi then () else (f lo; for (lo + 1, hi) f)
+  fun for (lo, hi) f = if lo >= hi then () else (f lo; for (lo + 1, hi) f)
 
   fun gtOfCmp cmp (x, y) =
     case cmp (x, y) of

--- a/src/base/WithSource.sml
+++ b/src/base/WithSource.sml
@@ -23,6 +23,5 @@ struct
   fun valOf {value, source = _} = value
   fun srcOf {value = _, source} = source
 
-  fun map f {value, source} =
-    make {value = f value, source = source}
+  fun map f {value, source} = make {value = f value, source = source}
 end

--- a/src/lex-mlb/MLBLexer.sml
+++ b/src/lex-mlb/MLBLexer.sml
@@ -52,21 +52,16 @@ struct
       val src = Source.wholeFile src
 
       (** Some helpers for making source slices and tokens. *)
-      fun slice (i, j) =
-        Source.slice src (i, j - i)
-      fun sliceFrom i =
-        slice (i, Source.length src)
-      fun mkr x (i, j) =
-        MLBToken.Pretoken.reserved (slice (i, j)) x
+      fun slice (i, j) = Source.slice src (i, j - i)
+      fun sliceFrom i = slice (i, Source.length src)
+      fun mkr x (i, j) = MLBToken.Pretoken.reserved (slice (i, j)) x
 
       fun get i = Source.nth src i
 
       fun isEndOfFileAt i = i >= Source.length src
 
-      fun check f i =
-        i < Source.length src andalso f (get i)
-      fun is c =
-        check (fn c' => c = c')
+      fun check f i = i < Source.length src andalso f (get i)
+      fun is c = check (fn c' => c = c')
 
       fun isString str i =
         Source.length src - i >= String.size str
@@ -174,8 +169,7 @@ struct
       fun tokEndOffset tok =
         Source.absoluteEndOffset (MLBToken.Pretoken.getSource tok)
 
-      fun finish acc =
-        MLBToken.makeGroup (Seq.fromRevList acc)
+      fun finish acc = MLBToken.makeGroup (Seq.fromRevList acc)
 
       fun loop acc offset =
         if offset >= endOffset then

--- a/src/lex-mlb/MLBToken.sml
+++ b/src/lex-mlb/MLBToken.sml
@@ -71,11 +71,9 @@ struct
   fun fromSMLPretoken ptok =
     make (Token.Pretoken.getSource ptok) (SML (Token.Pretoken.getClass ptok))
 
-  fun getClass ({idx, context}: token) =
-    WithSource.valOf (Seq.nth context idx)
+  fun getClass ({idx, context}: token) = WithSource.valOf (Seq.nth context idx)
 
-  fun getSource ({idx, context}: token) =
-    WithSource.srcOf (Seq.nth context idx)
+  fun getSource ({idx, context}: token) = WithSource.srcOf (Seq.nth context idx)
 
   fun isComment tok =
     case getClass tok of
@@ -163,8 +161,7 @@ struct
   fun makeGroup (s: pretoken Seq.t) : token Seq.t =
     Seq.tabulate (fn i => {idx = i, context = s}) (Seq.length s)
 
-  fun fromPre (t: pretoken) =
-    Seq.nth (makeGroup (Seq.singleton t)) 0
+  fun fromPre (t: pretoken) = Seq.nth (makeGroup (Seq.singleton t)) 0
 
 
   structure Pretoken =

--- a/src/lex/LexUtils.sml
+++ b/src/lex/LexUtils.sml
@@ -10,8 +10,7 @@ struct
 
   val isValidSingleEscapeChar = Char.contains "abtnvfr\\\""
 
-  fun isValidControlEscapeChar c =
-    64 <= Char.ord c andalso Char.ord c <= 95
+  fun isValidControlEscapeChar c = 64 <= Char.ord c andalso Char.ord c <= 95
 
   val isSymbolic = Char.contains "!%&$#+-/:<=>?@\\~`^|*"
 

--- a/src/lex/Lexer.sml
+++ b/src/lex/Lexer.sml
@@ -34,12 +34,9 @@ struct
       val src = Source.wholeFile src
 
       (** Some helpers for making source slices and tokens. *)
-      fun slice (i, j) =
-        Source.slice src (i, j - i)
-      fun mk x (i, j) =
-        Token.Pretoken.make (slice (i, j)) x
-      fun mkr x (i, j) =
-        Token.Pretoken.reserved (slice (i, j)) x
+      fun slice (i, j) = Source.slice src (i, j - i)
+      fun mk x (i, j) = Token.Pretoken.make (slice (i, j)) x
+      fun mkr x (i, j) = Token.Pretoken.reserved (slice (i, j)) x
 
       fun get i = Source.nth src i
 
@@ -51,21 +48,15 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i =
-        i < Source.length src andalso f (get i)
-      fun is c =
-        check (fn c' => c = c')
+      fun check f i = i < Source.length src andalso f (get i)
+      fun is c = check (fn c' => c = c')
 
 
-      fun isPrint c =
-        let val i = Char.ord c
-        in 32 <= i andalso i <= 126
-        end
+      fun isPrint c = let val i = Char.ord c in 32 <= i andalso i <= 126 end
 
-      fun isMaybeUnicode c =
-        let val i = Char.ord c
-        in (128 <= i andalso i <= 253) (* ?? *)
-        end
+      fun isMaybeUnicode c = let val i = Char.ord c
+                             in (128 <= i andalso i <= 253) (* ?? *)
+                             end
 
 
       (** ====================================================================
@@ -662,8 +653,7 @@ struct
       fun tokEndOffset tok =
         Source.absoluteEndOffset (Token.Pretoken.getSource tok)
 
-      fun finish acc =
-        Token.makeGroup (Seq.rev (Seq.fromList acc))
+      fun finish acc = Token.makeGroup (Seq.rev (Seq.fromList acc))
 
       fun loop acc offset =
         if offset >= endOffset then

--- a/src/lex/Token.sml
+++ b/src/lex/Token.sml
@@ -266,11 +266,9 @@ struct
 
   fun identifier src = WithSource.make {value = Identifier, source = src}
 
-  fun getClass ({idx, context}: token) =
-    WithSource.valOf (Seq.nth context idx)
+  fun getClass ({idx, context}: token) = WithSource.valOf (Seq.nth context idx)
 
-  fun getSource ({idx, context}: token) =
-    WithSource.srcOf (Seq.nth context idx)
+  fun getSource ({idx, context}: token) = WithSource.srcOf (Seq.nth context idx)
 
   fun lineDifference (tok1, tok2) =
     let
@@ -293,10 +291,9 @@ struct
       lnEnd <> lnStart
     end
 
-  fun toString tok =
-    let val src = getSource tok
-    in CharVector.tabulate (Source.length src, Source.nth src)
-    end
+  fun toString tok = let val src = getSource tok
+                     in CharVector.tabulate (Source.length src, Source.nth src)
+                     end
 
   fun tryReserved src =
     let
@@ -466,10 +463,9 @@ struct
       Reserved Orelse => true
     | _ => false
 
-  fun isStar tok =
-    let val src = getSource tok
-    in Source.length src = 1 andalso Source.nth src 0 = #"*"
-    end
+  fun isStar tok = let val src = getSource tok
+                   in Source.length src = 1 andalso Source.nth src 0 = #"*"
+                   end
 
   fun isOpenParen tok =
     case getClass tok of
@@ -779,8 +775,7 @@ struct
   fun makeGroup (s: pretoken Seq.t) : token Seq.t =
     Seq.tabulate (fn i => {idx = i, context = s}) (Seq.length s)
 
-  fun fromPre (t: pretoken) =
-    Seq.nth (makeGroup (Seq.singleton t)) 0
+  fun fromPre (t: pretoken) = Seq.nth (makeGroup (Seq.singleton t)) 0
 
   fun nextToken ({idx = i, context}: token) =
     if i + 1 < Seq.length context then SOME {idx = i + 1, context = context}

--- a/src/parse-mlb/MLBParser.sml
+++ b/src/parse-mlb/MLBParser.sml
@@ -18,8 +18,7 @@ struct
   type ('a, 'b) parser = ('a, 'b) ParserCombinators.parser
   type tokens = MLBToken.t Seq.t
 
-  fun check_ toks f i =
-    i < Seq.length toks andalso f (Seq.nth toks i)
+  fun check_ toks f i = i < Seq.length toks andalso f (Seq.nth toks i)
 
   fun isReserved_ toks rc i =
     check_ toks
@@ -169,12 +168,9 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        check_ toks f i
-      fun isReserved rc i =
-        isReserved_ toks rc i
-      fun isSMLReserved rc i =
-        isSMLReserved_ toks rc i
+      fun check f i = check_ toks f i
+      fun isReserved rc i = isReserved_ toks rc i
+      fun isSMLReserved rc i = isSMLReserved_ toks rc i
 
 
       (** bas basdec end
@@ -234,17 +230,13 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        check_ toks f i
-      fun isReserved rc i =
-        isReserved_ toks rc i
-      fun isSMLReserved rc i =
-        isSMLReserved_ toks rc i
+      fun check f i = check_ toks f i
+      fun isReserved rc i = isReserved_ toks rc i
+      fun isSMLReserved rc i = isSMLReserved_ toks rc i
 
 
       (** not yet implemented *)
-      fun nyi fname i =
-        nyi_ toks fname i
+      fun nyi fname i = nyi_ toks fname i
 
 
       fun makeSMLPath pathtok pathstr =
@@ -279,10 +271,8 @@ struct
 
           val pathstr = Source.toString (Source.slice thisSrc (1, n - 2))
 
-          fun mlbCase () =
-            (i + 1, makeMLBPath thisTok pathstr)
-          fun smlCase () =
-            (i + 1, makeSMLPath thisTok pathstr)
+          fun mlbCase () = (i + 1, makeMLBPath thisTok pathstr)
+          fun smlCase () = (i + 1, makeSMLPath thisTok pathstr)
         in
           case OS.Path.ext pathstr of
             SOME "mlb" => mlbCase ()

--- a/src/parse-mlb/ParseAnnotations.sml
+++ b/src/parse-mlb/ParseAnnotations.sml
@@ -80,7 +80,6 @@ struct
     end
 
 
-  fun modifyAllows allows anns =
-    Seq.iterate modifyOne allows anns
+  fun modifyAllows allows anns = Seq.iterate modifyOne allows anns
 
 end

--- a/src/parse/InfixDict.sml
+++ b/src/parse/InfixDict.sml
@@ -43,10 +43,8 @@ struct
 
   type t = fixity D.t list
 
-  fun L (str, p) =
-    (str, Infix (p, AssocLeft))
-  fun R (str, p) =
-    (str, Infix (p, AssocRight))
+  fun L (str, p) = (str, Infix (p, AssocLeft))
+  fun R (str, p) = (str, Infix (p, AssocRight))
 
   val initialTopLevel: t =
     [fromList
@@ -78,8 +76,7 @@ struct
 
   fun popScope [_] = raise TopScope
     | popScope (x :: d) = {old = d, popped = [x]}
-    | popScope [] =
-        raise Fail "Impossible! Bug in InfixDict"
+    | popScope [] = raise Fail "Impossible! Bug in InfixDict"
 
   fun find d tok =
     let
@@ -118,11 +115,9 @@ struct
       SOME (Infix (_, a)) => a
     | _ => raise NotFound
 
-  fun associatesLeft d tok =
-    AssocLeft = lookupAssoc d tok
+  fun associatesLeft d tok = AssocLeft = lookupAssoc d tok
 
-  fun associatesRight d tok =
-    AssocRight = lookupAssoc d tok
+  fun associatesRight d tok = AssocRight = lookupAssoc d tok
 
   fun higherPrecedence d (tok1, tok2) =
     lookupPrecedence d tok1 > lookupPrecedence d tok2

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -144,19 +144,14 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun is c =
-        check (fn t => c = Token.getClass t)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun is c = check (fn t => c = Token.getClass t)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
 
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
       fun parse_tyvars i = PS.tyvars toks i
-      fun parse_maybeReserved rc i =
-        PS.maybeReserved toks rc i
+      fun parse_maybeReserved rc i = PS.maybeReserved toks rc i
       fun parse_vid i = PS.vid toks i
       fun parse_longvid i = PS.longvid toks i
       fun parse_recordLabel i = PS.recordLabel toks i
@@ -170,10 +165,8 @@ struct
         PC.zeroOrMoreDelimitedByReserved toks x i
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
-      fun parse_two (p1, p2) state =
-        PC.two (p1, p2) state
-      fun parse_zeroOrMoreWhile c p s =
-        PC.zeroOrMoreWhile c p s
+      fun parse_two (p1, p2) state = PC.two (p1, p2) state
+      fun parse_zeroOrMoreWhile c p s = PC.zeroOrMoreWhile c p s
 
       fun consume_exp infdict restriction i =
         exp allows toks infdict restriction i
@@ -700,18 +693,13 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun is c =
-        check (fn t => c = Token.getClass t)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun is c = check (fn t => c = Token.getClass t)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
 
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
-      fun parse_maybeReserved rc i =
-        PS.maybeReserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
+      fun parse_maybeReserved rc i = PS.maybeReserved toks rc i
       fun parse_vid i = PS.vid toks i
       fun parse_longvid i = PS.longvid toks i
       fun parse_recordLabel i = PS.recordLabel toks i
@@ -724,10 +712,8 @@ struct
         PC.zeroOrMoreDelimitedByReserved toks x i
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
-      fun parse_two (p1, p2) state =
-        PC.two (p1, p2) state
-      fun parse_zeroOrMoreWhile c p s =
-        PC.zeroOrMoreWhile c p s
+      fun parse_two (p1, p2) state = PC.two (p1, p2) state
+      fun parse_zeroOrMoreWhile c p s = PC.zeroOrMoreWhile c p s
 
 
       fun consume_dec xx =

--- a/src/parse/ParseFunNameArgs.sml
+++ b/src/parse/ParseFunNameArgs.sml
@@ -30,8 +30,7 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
+      fun check f i = i < numToks andalso f (tok i)
       fun isReserved rc i =
         check (fn t => Token.Reserved rc = Token.getClass t) i
 

--- a/src/parse/ParsePat.sml
+++ b/src/parse/ParsePat.sml
@@ -64,14 +64,12 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
+      fun check f i = i < numToks andalso f (tok i)
       fun isReserved rc i =
         check (fn t => Token.Reserved rc = Token.getClass t) i
 
       fun parse_longvid i = PS.longvid toks i
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
       fun parse_zeroOrMoreDelimitedByReserved x i =

--- a/src/parse/ParseSigExpAndSpec.sml
+++ b/src/parse/ParseSigExpAndSpec.sml
@@ -37,13 +37,10 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
       fun parse_tyvars i = PS.tyvars toks i
       fun parse_sigid i = PS.sigid toks i
       fun parse_strid i = PS.strid toks i
@@ -58,12 +55,9 @@ struct
 
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
-      fun parse_two (p1, p2) state =
-        PC.two (p1, p2) state
-      fun parse_zeroOrMoreWhile c p s =
-        PC.zeroOrMoreWhile c p s
-      fun parse_oneOrMoreWhile c p s =
-        PC.oneOrMoreWhile c p s
+      fun parse_two (p1, p2) state = PC.two (p1, p2) state
+      fun parse_zeroOrMoreWhile c p s = PC.zeroOrMoreWhile c p s
+      fun parse_oneOrMoreWhile c p s = PC.oneOrMoreWhile c p s
 
 
       (** sigexp where type tyvarseq tycon = ty [and/where type ...]
@@ -142,15 +136,11 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
-      fun parse_maybeReserved rc i =
-        PS.maybeReserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
+      fun parse_maybeReserved rc i = PS.maybeReserved toks rc i
       fun parse_tyvars i = PS.tyvars toks i
       fun parse_vid i = PS.vid toks i
       fun parse_longvid i = PS.longvid toks i
@@ -162,12 +152,9 @@ struct
 
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
-      fun parse_two (p1, p2) state =
-        PC.two (p1, p2) state
-      fun parse_zeroOrMoreWhile c p s =
-        PC.zeroOrMoreWhile c p s
-      fun parse_oneOrMoreWhile c p s =
-        PC.oneOrMoreWhile c p s
+      fun parse_two (p1, p2) state = PC.two (p1, p2) state
+      fun parse_zeroOrMoreWhile c p s = PC.zeroOrMoreWhile c p s
+      fun parse_oneOrMoreWhile c p s = PC.oneOrMoreWhile c p s
 
 
       fun parse_datdesc i =
@@ -623,10 +610,8 @@ struct
     * ========================================================================
     *)
 
-  fun spec allows toks infdict i =
-    parse_spec allows toks infdict i
-  fun sigexp allows toks infdict i =
-    parse_sigexp allows toks infdict i
+  fun spec allows toks infdict i = parse_spec allows toks infdict i
+  fun sigexp allows toks infdict i = parse_sigexp allows toks infdict i
 
 
 end

--- a/src/parse/ParseTy.sml
+++ b/src/parse/ParseTy.sml
@@ -23,14 +23,12 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
+      fun check f i = i < numToks andalso f (tok i)
       fun isReserved rc i =
         check (fn t => Token.Reserved rc = Token.getClass t) i
 
       fun parse_recordLabel i = PS.recordLabel toks i
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
       fun parse_zeroOrMoreDelimitedByReserved x i =
         PC.zeroOrMoreDelimitedByReserved toks x i
 

--- a/src/parse/Parser.sml
+++ b/src/parse/Parser.sml
@@ -40,8 +40,7 @@ struct
 
 
       (** not yet implemented *)
-      fun nyi fname i =
-        ParserUtils.nyi toks fname i
+      fun nyi fname i = ParserUtils.nyi toks fname i
 
 
       (** This silliness lets you write almost-English like this:
@@ -51,16 +50,12 @@ struct
         *)
       infix 5 at
       fun f at i = f i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun is c =
-        check (fn t => c = Token.getClass t)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun is c = check (fn t => c = Token.getClass t)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
 
-      fun parse_reserved rc i =
-        PS.reserved toks rc i
+      fun parse_reserved rc i = PS.reserved toks rc i
       fun parse_tyvars i = PS.tyvars toks i
       fun parse_sigid i = PS.sigid toks i
       fun parse_strid i = PS.strid toks i
@@ -75,12 +70,9 @@ struct
 
       fun parse_oneOrMoreDelimitedByReserved x i =
         PC.oneOrMoreDelimitedByReserved toks x i
-      fun parse_two (p1, p2) state =
-        PC.two (p1, p2) state
-      fun parse_zeroOrMoreWhile c p s =
-        PC.zeroOrMoreWhile c p s
-      fun parse_oneOrMoreWhile c p s =
-        PC.oneOrMoreWhile c p s
+      fun parse_two (p1, p2) state = PC.two (p1, p2) state
+      fun parse_zeroOrMoreWhile c p s = PC.zeroOrMoreWhile c p s
+      fun parse_oneOrMoreWhile c p s = PC.oneOrMoreWhile c p s
 
       fun consume_sigExp infdict i =
         ParseSigExpAndSpec.sigexp allows toks infdict i

--- a/src/parse/ParserCombinators.sml
+++ b/src/parse/ParserCombinators.sml
@@ -37,10 +37,8 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun loop elems delims i =
         if shouldStop i then
@@ -64,10 +62,8 @@ struct
     let
       val numToks = Seq.length toks
       fun tok i = Seq.nth toks i
-      fun check f i =
-        i < numToks andalso f (tok i)
-      fun isReserved rc =
-        check (fn t => Token.Reserved rc = Token.getClass t)
+      fun check f i = i < numToks andalso f (tok i)
+      fun isReserved rc = check (fn t => Token.Reserved rc = Token.getClass t)
 
       fun loop elems delims i =
         let

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -96,8 +96,7 @@ struct
     end
 
 
-  fun appWantsSpace left right =
-    not (appWantsToTouch left right)
+  fun appWantsSpace left right = not (appWantsToTouch left right)
 
 
   fun tryViewAsSimpleApp exp =
@@ -493,8 +492,7 @@ struct
 
         | Tuple {left, elems, delims, right} =>
             let
-              fun make (e, d) =
-                withNewChild showExp tab e ++ nospace ++ token d
+              fun make (e, d) = withNewChild showExp tab e ++ nospace ++ token d
             in
               token left
               ++
@@ -744,8 +742,7 @@ struct
             open Ast.Exp
             val (chain, last) = ifThenElseChain [] exp
 
-            fun breakShowAt tab e =
-              at tab (showExp tab e)
+            fun breakShowAt tab e = at tab (showExp tab e)
 
             fun f i =
               let

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -947,30 +947,10 @@ struct
       fun showColonTy tab {ty: Ast.Ty.t, colon: Token.t} =
         token colon ++ withNewChild showTy tab ty
 
-      fun showClause mainTab clauseTab clauseChildStyleFirst
-        clauseChildStyleRest isFirst (front, {fname_args, ty, eq, exp}) =
-        let
-          fun afterFront tab clauseChildStyle =
-            let
-              val expChildStyle =
-                if isBiggishExp exp then
-                  Tab.Style.combine
-                    ( Tab.Style.combine (Tab.Style.indented, Tab.Style.rigid)
-                    , clauseChildStyle
-                    )
-                else
-                  clauseChildStyle
-            in
-              showFNameArgs tab clauseChildStyle fname_args
-              ++ showOption (showColonTy tab) ty ++ token eq
-              ++ withNewChildWithStyle expChildStyle showExp tab exp
-            end
-        in
-          if isFirst then
-            at mainTab (front ++ afterFront mainTab clauseChildStyleFirst)
-          else
-            at clauseTab (front ++ afterFront clauseTab clauseChildStyleRest)
-        end
+      fun showClause tab clauseChildStyle (front, {fname_args, ty, eq, exp}) =
+        at tab front ++ showFNameArgs tab clauseChildStyle fname_args
+        ++ showOption (showColonTy tab) ty ++ token eq
+        ++ withNewChildWithStyle clauseChildStyle showExp tab exp
 
       fun mkFunction (starter, {elems = innerElems, delims, optbar}) =
         let
@@ -993,9 +973,14 @@ struct
           at tab (newTabWithStyle tab (mainStyle, fn mainTab =>
             newTabWithStyle mainTab (clauseStyle, fn clauseTab =>
               let
-                val showClause' =
-                  showClause mainTab clauseTab clauseChildStyleFirst
-                    clauseChildStyleRest
+                fun showClause' isFirst =
+                  let
+                    val (tab, clauseChildStyle) =
+                      if isFirst then (mainTab, clauseChildStyleFirst)
+                      else (clauseTab, clauseChildStyleRest)
+                  in
+                    showClause tab clauseChildStyle
+                  end
               in
                 case optbar of
                   NONE =>

--- a/src/prettier-print/PrettierPat.sml
+++ b/src/prettier-print/PrettierPat.sml
@@ -120,8 +120,7 @@ struct
       | Or {elems, delims} =>
           newTab tab (fn tab =>
             let
-              fun f (d, p) =
-                at tab (token d) ++ withNewChild showPat tab p
+              fun f (d, p) = at tab (token d) ++ withNewChild showPat tab p
 
               val front = at tab (showPat tab (Seq.nth elems 0))
             in

--- a/src/prettier-print/PrettierPrintAst.sml
+++ b/src/prettier-print/PrettierPrintAst.sml
@@ -52,8 +52,7 @@ struct
 
   fun pretty {ribbonFrac, maxWidth, tabWidth, indent, debug} ast =
     let
-      fun dbgprintln s =
-        if not debug then () else print (s ^ "\n")
+      fun dbgprintln s = if not debug then () else print (s ^ "\n")
       val (doc, tm) = Util.getTime (fn _ => showAst ast)
       val _ = dbgprintln ("to-doc: " ^ Time.fmt 3 tm ^ "s")
     (* val doc = TokenDoc.insertComments doc

--- a/src/prettier-print/PrettierUtil.sml
+++ b/src/prettier-print/PrettierUtil.sml
@@ -66,8 +66,7 @@ struct
     newTabWithStyle tab (style, fn inner => at inner (shower inner x))
 
 
-  fun spaces n =
-    List.foldl op++ empty (List.tabulate (n, fn _ => space))
+  fun spaces n = List.foldl op++ empty (List.tabulate (n, fn _ => space))
 
 
   fun showSequence elemStartsWithStar (elemShower: 'a shower) tab

--- a/src/prettier-print/TabbedTokenDoc.sml
+++ b/src/prettier-print/TabbedTokenDoc.sml
@@ -25,11 +25,9 @@ local
         TerminalColors.hsv {h = h, s = s, v = 0.9}
       end
 
-    fun emphasize depth s =
-      backgroundIfNone (niceRed depth) s
+    fun emphasize depth s = backgroundIfNone (niceRed depth) s
 
-    fun toString t =
-      TerminalColorString.toString {colors = false} t
+    fun toString t = TerminalColorString.toString {colors = false} t
   end
 
 

--- a/src/pretty-print/PrettyExpAndDec.sml
+++ b/src/pretty-print/PrettyExpAndDec.sml
@@ -353,8 +353,7 @@ struct
           let
             fun showBranch {pat, arrow, exp} =
               showPat pat ++ space ++ token arrow \\ showExp exp
-            fun mk (delim, branch) =
-              token delim ++ space ++ showBranch branch
+            fun mk (delim, branch) = token delim ++ space ++ showBranch branch
           in
             showExp expLeft
             \\
@@ -370,8 +369,7 @@ struct
           let
             fun showBranch {pat, arrow, exp} =
               showPat pat ++ space ++ token arrow \\ showExp exp
-            fun mk (delim, branch) =
-              token delim ++ space ++ showBranch branch
+            fun mk (delim, branch) = token delim ++ space ++ showBranch branch
           in
             rigid
               (token casee ++ space ++ showExp expTop ++ space ++ token off
@@ -453,8 +451,7 @@ struct
               SOME (group
                 (group (showExp l $$ token t) +$+ showInfixedExp (rl, rt, rr)))
 
-      fun normal () =
-        group (group (showExp l $$ token t) +$+ showExp r)
+      fun normal () = group (group (showExp l $$ token t) +$+ showExp r)
     in
       case tryLeft () of
         SOME x => x

--- a/src/pretty-print/PrettyTy.sml
+++ b/src/pretty-print/PrettyTy.sml
@@ -37,8 +37,7 @@ struct
       | Tuple {elems, delims} =>
           let
             val begin = showTy (Seq.nth elems 0)
-            fun f (delim, x) =
-              space ++ token delim ++ space ++ showTy x
+            fun f (delim, x) = space ++ token delim ++ space ++ showTy x
           in
             Seq.iterate op++ begin (Seq.map f (Seq.zip
               (delims, Seq.drop elems 1)))

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -12,8 +12,7 @@ struct
   fun x ++ y = beside (x, y)
   fun x $$ y = aboveOrSpace (x, y)
   fun x // y = aboveOrBeside (x, y)
-  fun x \\ y =
-    group (x $$ indent y)
+  fun x \\ y = group (x $$ indent y)
 
   fun optBarFail () =
     raise Fail
@@ -44,8 +43,7 @@ struct
         (f (Seq.nth elems 0)) (Seq.drop elems 1)
 
 
-  fun spaces n =
-    List.foldl op++ empty (List.tabulate (n, fn _ => space))
+  fun spaces n = List.foldl op++ empty (List.tabulate (n, fn _ => space))
 
 
   fun sequence openn delims close (xs: doc Seq.t) =
@@ -54,8 +52,7 @@ struct
     else
       let
         val top = token openn ++ softspace ++ Seq.nth xs 0
-        fun f (delim, x) =
-          token delim ++ space ++ x
+        fun f (delim, x) = token delim ++ space ++ x
       in
         group
           (Seq.iterate op// top (Seq.map f (Seq.zip (delims, Seq.drop xs 1)))

--- a/src/pretty-print/TokenDoc.sml
+++ b/src/pretty-print/TokenDoc.sml
@@ -109,10 +109,8 @@ struct
       fun blankLinesAbove d n =
         if n <= 0 then d else blankLinesAbove (Above (false, space, d)) (n - 1)
 
-      fun preferRight (a, b) =
-        if Option.isSome b then b else a
-      fun preferLeft (a, b) =
-        if Option.isSome a then a else b
+      fun preferRight (a, b) = if Option.isSome b then b else a
+      fun preferLeft (a, b) = if Option.isSome a then a else b
 
       fun doDoc doc =
         case doc of

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -5,8 +5,7 @@
 
 structure TCS = TerminalColorString
 structure TC = TerminalColors
-fun boldc c x =
-  TCS.bold (TCS.foreground c (TCS.fromString x))
+fun boldc c x = TCS.bold (TCS.foreground c (TCS.fromString x))
 fun printErr m = TextIO.output (TextIO.stdErr, m)
 
 val optionalArgDesc =
@@ -93,8 +92,7 @@ val preview = CommandLineArgs.parseFlag "preview"
 val previewOnly = CommandLineArgs.parseFlag "preview-only"
 val showPreview = preview orelse previewOnly
 
-fun dbgprintln s =
-  if not doDebug then () else print (s ^ "\n")
+fun dbgprintln s = if not doDebug then () else print (s ^ "\n")
 
 val allows = AstAllows.make
   { topExp = allowTopExp
@@ -112,8 +110,7 @@ val _ =
   then (print (usage ()); OS.Process.exit OS.Process.success)
   else ()
 
-fun warnWithMessage msg =
-  TCS.printErr (boldc Palette.yellow (msg ^ "\n"))
+fun warnWithMessage msg = TCS.printErr (boldc Palette.yellow (msg ^ "\n"))
 
 fun failWithMessage msg =
   ( TCS.printErr (boldc Palette.red (msg ^ "\n"))

--- a/src/syntax-highlighting/SyntaxHighlighter.sml
+++ b/src/syntax-highlighting/SyntaxHighlighter.sml
@@ -120,8 +120,7 @@ struct
       fun tokEndOffset tok =
         Source.absoluteEndOffset (Token.Pretoken.getSource tok)
 
-      fun finish acc =
-        Token.makeGroup (Seq.fromRevList acc)
+      fun finish acc = Token.makeGroup (Seq.fromRevList acc)
 
       fun loop acc offset =
         if offset >= endOffset then


### PR DESCRIPTION
Don't force "biggish" fun-decl-body expressions onto new line.

Fixes #82

While this addresses the main issue raised by #82, it does not exactly replicate the logic of `val` decls.  I tried doing something closer to [`PrettierExpAndDec.sml#L815:L817`](https://github.com/shwestrick/smlfmt/blob/8bfbf349e1e01e505e22ccd6c4110f8100b585fa/src/prettier-print/PrettierExpAndDec.sml#L815:L817), with a `showClauseSplittable` that uses `cond` and `splitShowExpLeft`/`splitShowExpRight`, but I found the [`isSplittable`](https://github.com/shwestrick/smlfmt/blob/8bfbf349e1e01e505e22ccd6c4110f8100b585fa/src/prettier-print/PrettierExpAndDec.sml#L201:L215) condition for `App` to frequently leave a single token on the `fun` line after the `=` token, followed by a much larger expression on the next line, which often looked awkward if not outright misleading; for example:

```diff
-    fun indentedAtLeastBy i =                                                                                                                                    
-      S { indent = Indented {minIndent = SOME i, maxIndent = NONE}                                                                                               
-        , rigid = false                                                                                                                                          
-        , allowsComments = false                                                                                                                                 
-        }                                                                                                                                                        
+    fun indentedAtLeastBy i = S                                                                                                                                  
+      { indent = Indented {minIndent = SOME i, maxIndent = NONE}                                                                                                 
+      , rigid = false                                                                                                                                            
+      , allowsComments = false                                                                                                                                   
+      }                                                                                                                                                          
```
or
```diff
-          fun continue i =                                                                                                                                       
-            not (isReserved Token.Colon i orelse isReserved Token.Equal i)                                                                                       
+          fun continue i = not                                                                                                                                   
+            (isReserved Token.Colon i orelse isReserved Token.Equal i)                                                                                           
```
