### PR TITLE
Add support for SuccessorML withtype in signatures syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ install: smlfmt
 	install -d $(DESTDIR)$(PREFIX)/bin/
 	install -m 755 smlfmt $(DESTDIR)$(PREFIX)/bin/
 
+.PHONY: test
+test: smlfmt
+	test/runall
+
 .PHONY: clean
 clean:
 	rm -f demo smlfmt

--- a/README.md
+++ b/README.md
@@ -135,3 +135,6 @@ SuccessorML or-pattern syntax is allowed.
 `-allow-extended-text-consts [true|false]` (default `false`) controls whether
 or not SuccessorML extended text constants are allowed. Enable this to allow
 for UTF-8 characters within strings.
+
+`-allow-sig-withtype [true|false]` (default `false`) controls whether or not
+SuccessorML `withtype` in signatures syntax is allowed.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ that the `--preview-only` flag is also enabled.
 `-allow-top-level-exps [true|false]` (default `true`) controls whether or
 not top-level expressions (terminated by a semicolon) are allowed.
 
+`-allow-successor-ml [true|false]` (default `false`) controls whether or not
+SuccessorML features are allowed.
+
 `-allow-opt-bar [true|false]` (default `false`) controls whether or not
 SuccessorML optional bar syntax is allowed.
 

--- a/src/ast/AstType.sml
+++ b/src/ast/AstType.sml
@@ -475,6 +475,16 @@ struct
   structure Sig =
   struct
 
+    (** tyvarseq tycon = ty [and tyvarseq tycon = ty ...] *)
+    (* This is the same as Exp.typbind *)
+    type typbind =
+      { elems:
+          {tyvars: Token.t SyntaxSeq.t, tycon: Token.t, eq: Token.t, ty: Ty.t} Seq.t
+      (** the `and` delimiters between bindings *)
+      , delims: Token.t Seq.t
+      }
+
+
     datatype spec =
       EmptySpec
 
@@ -494,13 +504,7 @@ struct
         , delims: Token.t Seq.t
         }
 
-    | TypeAbbreviation of
-        { typee: Token.t
-        , elems:
-            {tyvars: Token.t SyntaxSeq.t, tycon: Token.t, eq: Token.t, ty: Ty.t} Seq.t
-        (** 'and' delimiters between mutually recursive types *)
-        , delims: Token.t Seq.t
-        }
+    | TypeAbbreviation of {typee: Token.t, typbind: typbind}
 
     (** eqtype tyvarseq tycon [and tyvarseq tycon ...] *)
     | Eqtype of
@@ -525,6 +529,8 @@ struct
             } Seq.t
         (** 'and' delimiters between mutually recursive datatypes *)
         , delims: Token.t Seq.t
+        (** SuccessorML: withtype in signatures *)
+        , withtypee: {withtypee: Token.t, typbind: typbind} option
         }
 
     (** datatype tycon = datatype longtycon *)

--- a/src/ast/CompareAst.sml
+++ b/src/ast/CompareAst.sml
@@ -753,16 +753,8 @@ struct
             end
 
         | (Sig.TypeAbbreviation a1, Sig.TypeAbbreviation a2) =>
-            let
-              val checker =
-                at #typee equal_tok
-                <&>
-                at #elems (Seq.equal
-                  (at #tyvars (equal_syntaxseq equal_tok)
-                   <&> at #tycon equal_tok <&> at #eq equal_tok
-                   <&> at #ty equal_ty)) <&> at #delims (Seq.equal equal_tok)
-            in
-              checker (a1, a2)
+            let val checker = at #typee equal_tok <&> at #typbind equal_typbind
+            in checker (a1, a2)
             end
 
         | (Sig.Eqtype e1, Sig.Eqtype e2) =>

--- a/src/base/AstAllows.sml
+++ b/src/base/AstAllows.sml
@@ -13,6 +13,7 @@ sig
     , recordPun: bool
     , orPat: bool
     , extendedText: bool
+    , sigWithtype: bool
     }
     -> t
 
@@ -21,6 +22,7 @@ sig
   val recordPun: t -> bool
   val orPat: t -> bool
   val extendedText: t -> bool
+  val sigWithtype: t -> bool
 end =
 struct
   datatype t =
@@ -30,6 +32,7 @@ struct
       , recordPun: bool
       , orPat: bool
       , extendedText: bool
+      , sigWithtype: bool
       }
 
   fun make x = T x
@@ -38,4 +41,5 @@ struct
   fun recordPun (T x) = #recordPun x
   fun orPat (T x) = #orPat x
   fun extendedText (T x) = #extendedText x
+  fun sigWithtype (T x) = #sigWithtype x
 end

--- a/src/lex-mlb/MLBLexer.sml
+++ b/src/lex-mlb/MLBLexer.sml
@@ -33,6 +33,7 @@ struct
         , recordPun = false
         , orPat = false
         , extendedText = false
+        , sigWithtype = false
         }
     in
       case Lexer.next smlLexerAllows src of

--- a/src/parse-mlb/ParseAnnotations.sml
+++ b/src/parse-mlb/ParseAnnotations.sml
@@ -21,6 +21,7 @@ struct
       , recordPun = AstAllows.recordPun a
       , orPat = AstAllows.orPat a
       , extendedText = AstAllows.extendedText a
+      , sigWithtype = AstAllows.sigWithtype a
       }
 
 
@@ -31,6 +32,7 @@ struct
       , recordPun = b
       , orPat = AstAllows.orPat a
       , extendedText = AstAllows.extendedText a
+      , sigWithtype = AstAllows.sigWithtype a
       }
 
 
@@ -41,6 +43,7 @@ struct
       , recordPun = AstAllows.recordPun a
       , orPat = b
       , extendedText = AstAllows.extendedText a
+      , sigWithtype = AstAllows.sigWithtype a
       }
 
 
@@ -51,6 +54,17 @@ struct
       , recordPun = AstAllows.recordPun a
       , orPat = AstAllows.orPat a
       , extendedText = b
+      , sigWithtype = AstAllows.sigWithtype a
+      }
+
+  fun allowSigWithtype a b =
+    AstAllows.make
+      { optBar = AstAllows.optBar a
+      , topExp = AstAllows.topExp a
+      , recordPun = AstAllows.recordPun a
+      , orPat = AstAllows.orPat a
+      , extendedText = AstAllows.extendedText a
+      , sigWithtype = b
       }
 
 
@@ -76,6 +90,8 @@ struct
           allowExtendedTextConsts allows true
       | ["allowExtendedTextConsts", "false"] =>
           allowExtendedTextConsts allows false
+      | ["allowSigWithtype", "true"] => allowSigWithtype allows true
+      | ["allowSigWithtype", "false"] => allowSigWithtype allows false
       | _ => allows
     end
 

--- a/src/parse-mlb/ParseAnnotations.sml
+++ b/src/parse-mlb/ParseAnnotations.sml
@@ -14,6 +14,17 @@ struct
   type annotations = MLBToken.t Seq.t
 
 
+  fun allowSuccessorML a b =
+    AstAllows.make
+      { topExp = AstAllows.topExp a
+      , optBar = b
+      , recordPun = b
+      , orPat = b
+      , extendedText = b
+      , sigWithtype = b
+      }
+
+
   fun allowOptBar a b =
     AstAllows.make
       { optBar = b
@@ -68,35 +79,42 @@ struct
       }
 
 
-  fun modifyOne (allows, ann) =
+  fun getElems ann =
     let
       val src = MLBToken.getSource ann
 
       (* this strips the initial and final `"` characters from the string *)
       val str = CharVector.tabulate (Source.length src - 2, fn i =>
         Source.nth src (i + 1))
-
-      (* val _ = print ("processing annotation: '" ^ str ^ "'\n") *)
-      val elems = String.tokens Char.isSpace str
     in
-      case elems of
-        ["allowOptBar", "true"] => allowOptBar allows true
-      | ["allowOptBar", "false"] => allowOptBar allows false
-      | ["allowOrPats", "true"] => allowOrPats allows true
-      | ["allowOrPats", "false"] => allowOrPats allows false
-      | ["allowRecordPunExps", "true"] => allowRecordPunExps allows true
-      | ["allowRecordPunExps", "false"] => allowRecordPunExps allows false
-      | ["allowExtendedTextConsts", "true"] =>
-          allowExtendedTextConsts allows true
-      | ["allowExtendedTextConsts", "false"] =>
-          allowExtendedTextConsts allows false
-      | ["allowSigWithtype", "true"] => allowSigWithtype allows true
-      | ["allowSigWithtype", "false"] => allowSigWithtype allows false
-      | _ => allows
+      String.tokens Char.isSpace str
     end
 
 
+  fun applyGeneralAnn (allows, ann) =
+    case getElems ann of
+      ["allowSuccessorML", "true"] => allowSuccessorML allows true
+    | ["allowSuccessorML", "false"] => allowSuccessorML allows false
+    | _ => allows
+
+
+  fun applySpecificAnn (allows, ann) =
+    case getElems ann of
+      ["allowOptBar", "true"] => allowOptBar allows true
+    | ["allowOptBar", "false"] => allowOptBar allows false
+    | ["allowOrPats", "true"] => allowOrPats allows true
+    | ["allowOrPats", "false"] => allowOrPats allows false
+    | ["allowRecordPunExps", "true"] => allowRecordPunExps allows true
+    | ["allowRecordPunExps", "false"] => allowRecordPunExps allows false
+    | ["allowExtendedTextConsts", "true"] => allowExtendedTextConsts allows true
+    | ["allowExtendedTextConsts", "false"] =>
+        allowExtendedTextConsts allows false
+    | ["allowSigWithtype", "true"] => allowSigWithtype allows true
+    | ["allowSigWithtype", "false"] => allowSigWithtype allows false
+    | _ => allows
+
+
   fun modifyAllows allows anns =
-    Seq.iterate modifyOne allows anns
+    Seq.iterate applySpecificAnn (Seq.iterate applyGeneralAnn allows anns) anns
 
 end

--- a/src/parse/ParseExpAndDec.sml
+++ b/src/parse/ParseExpAndDec.sml
@@ -188,6 +188,7 @@ struct
         end
 
 
+      (* This function is duplicated in ParseSigExpAndSpec. *)
       fun parse_typbind i =
         let
           fun parseElem i =

--- a/src/prettier-print/PrettierExpAndDec.sml
+++ b/src/prettier-print/PrettierExpAndDec.sml
@@ -233,6 +233,7 @@ struct
 
   (* ====================================================================== *)
 
+  (* This function is duplicated in PrettierSig. *)
   fun showTypbind tab (front, typbind: Ast.Exp.typbind as {elems, delims}) =
     let
       fun showOne first (starter, {tyvars, tycon, ty, eq}) =

--- a/src/pretty-print/PrettySig.sml
+++ b/src/pretty-print/PrettySig.sml
@@ -49,7 +49,7 @@ struct
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
-    | Ast.Sig.TypeAbbreviation {typee, elems, delims} =>
+    | Ast.Sig.TypeAbbreviation {typee, typbind = {elems, delims}} =>
         let
           fun showOne (starter, {tyvars, tycon, eq, ty}) =
             separateWithSpaces
@@ -77,11 +77,13 @@ struct
             (Seq.zipWith showOne (delims, Seq.drop elems 1))
         end
 
-    | Ast.Sig.Datatype {datatypee, elems, delims} =>
+    | Ast.Sig.Datatype {datatypee, elems, delims, withtypee} =>
         (** This is *really* similar to a datbind (see showDatbind above), but
           * only one difference: there is no possible 'op' in the condesc, ugh.
           *)
         let
+          val _ = if Option.isSome withtypee then sigWithtypeFail () else ()
+
           fun showCon (starter, {vid, arg}) =
             starter ++ space
             ++

--- a/src/pretty-print/PrettyUtil.sml
+++ b/src/pretty-print/PrettyUtil.sml
@@ -36,6 +36,14 @@ struct
       \deprecation. Please use `-engine prettier` instead, \
       \which supports or-pattern."
 
+  fun sigWithtypeFail () =
+    raise Fail
+      "unsupported: SuccessorML withtype in signatures syntax. Note: \
+      \you are using `-engine pretty`, which is headed towards \
+      \deprecation. Please use `-engine prettier` instead, \
+      \which supports withtype in signatures."
+
+
   fun seqWithSpaces elems f =
     if Seq.length elems = 0 then
       empty

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -70,6 +70,11 @@ val optionalArgDesc =
   \                             Valid options are: true, false\n\
   \                             (default 'false')\n\
   \\n\
+  \  [-allow-sig-withtype B]    Enable/disable SuccessorML withtype in signatures\n\
+  \                             syntax.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'false')\n\
+  \\n\
   \  [--help]                   print this message\n"
 
 
@@ -92,6 +97,7 @@ val allowRecordPun = CommandLineArgs.parseBool "allow-record-pun-exps" false
 val allowOrPat = CommandLineArgs.parseBool "allow-or-pats" false
 val allowExtendedText =
   CommandLineArgs.parseBool "allow-extended-text-consts" false
+val allowSigWithtype = CommandLineArgs.parseBool "allow-sig-withtype" false
 
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"
@@ -112,6 +118,7 @@ val allows = AstAllows.make
   , recordPun = allowRecordPun
   , orPat = allowOrPat
   , extendedText = allowExtendedText
+  , sigWithtype = allowSigWithtype
   }
 
 val _ =

--- a/src/smlfmt.sml
+++ b/src/smlfmt.sml
@@ -51,6 +51,10 @@ val optionalArgDesc =
   \                             Valid options are: true, false\n\
   \                             (default 'true')\n\
   \\n\
+  \  [-allow-successor-ml B]    Enable/disable all SuccessorML features.\n\
+  \                             Valid options are: true, false\n\
+  \                             (default 'false')\n\
+  \\n\
   \  [-allow-opt-bar B]         Enable/disable SuccessorML optional bar syntax.\n\
   \                             Valid options are: true, false\n\
   \                             (default 'false')\n\
@@ -92,12 +96,15 @@ val engine = CommandLineArgs.parseString "engine" "prettier"
 val inputfiles = CommandLineArgs.positional ()
 
 val allowTopExp = CommandLineArgs.parseBool "allow-top-level-exps" true
-val allowOptBar = CommandLineArgs.parseBool "allow-opt-bar" false
-val allowRecordPun = CommandLineArgs.parseBool "allow-record-pun-exps" false
-val allowOrPat = CommandLineArgs.parseBool "allow-or-pats" false
+val allowSuccessorML = CommandLineArgs.parseBool "allow-successor-ml" false
+val allowOptBar = CommandLineArgs.parseBool "allow-opt-bar" allowSuccessorML
+val allowRecordPun =
+  CommandLineArgs.parseBool "allow-record-pun-exps" allowSuccessorML
+val allowOrPat = CommandLineArgs.parseBool "allow-or-pats" allowSuccessorML
 val allowExtendedText =
-  CommandLineArgs.parseBool "allow-extended-text-consts" false
-val allowSigWithtype = CommandLineArgs.parseBool "allow-sig-withtype" false
+  CommandLineArgs.parseBool "allow-extended-text-consts" allowSuccessorML
+val allowSigWithtype =
+  CommandLineArgs.parseBool "allow-sig-withtype" allowSuccessorML
 
 val doDebug = CommandLineArgs.parseFlag "debug-engine"
 val doForce = CommandLineArgs.parseFlag "force"

--- a/src/syntax-highlighting/SyntaxHighlighter.sml
+++ b/src/syntax-highlighting/SyntaxHighlighter.sml
@@ -111,6 +111,7 @@ struct
         , recordPun = true
         , orPat = true
         , extendedText = true
+        , sigWithtype = true
         }
 
       val startOffset = Source.absoluteStartOffset src

--- a/test/succeed/sig-withtype.mlb
+++ b/test/succeed/sig-withtype.mlb
@@ -1,0 +1,4 @@
+$(SML_LIB)/basis/basis.mlb
+ann "allowSigWithtype true" in
+  successor-ml/sig-withtype.sml
+end

--- a/test/succeed/successor-ml/sig-withtype.sml
+++ b/test/succeed/successor-ml/sig-withtype.sml
@@ -1,0 +1,5 @@
+signature STREAM =
+sig
+  datatype 'a u = Nil | Cons of 'a * 'a t
+  withtype 'a t = unit -> 'a u
+end


### PR DESCRIPTION
Also add an option to enable all SuccessorML features. See the commit messages for more details.